### PR TITLE
fix: close security gaps and add input validation

### DIFF
--- a/app/app/api/discord/webhook/route.ts
+++ b/app/app/api/discord/webhook/route.ts
@@ -19,13 +19,14 @@ import { createNotification } from "@/lib/notifications";
  * simpler integration scenarios or manual triggering.
  */
 export async function POST(req: NextRequest) {
-  // Verify webhook secret if configured
+  // Verify webhook secret — fail closed if not configured
   const webhookSecret = process.env.DISCORD_WEBHOOK_SECRET;
-  if (webhookSecret) {
-    const headerSecret = req.headers.get("X-Discord-Webhook-Secret");
-    if (headerSecret !== webhookSecret) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
-    }
+  if (!webhookSecret) {
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
+  }
+  const headerSecret = req.headers.get("X-Discord-Webhook-Secret");
+  if (headerSecret !== webhookSecret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
   }
 
   try {

--- a/app/app/api/listings/[id]/applications/route.ts
+++ b/app/app/api/listings/[id]/applications/route.ts
@@ -14,6 +14,9 @@ export async function PATCH(
 
   const { id } = await params;
   const listingId = parseInt(id, 10);
+  if (isNaN(listingId)) {
+    return NextResponse.json({ error: "Invalid listing ID" }, { status: 400 });
+  }
 
   const listing = db
     .prepare("SELECT * FROM listings WHERE id = ?")

--- a/app/app/api/listings/[id]/apply/route.ts
+++ b/app/app/api/listings/[id]/apply/route.ts
@@ -14,6 +14,9 @@ export async function POST(
 
   const { id } = await params;
   const listingId = parseInt(id, 10);
+  if (isNaN(listingId)) {
+    return NextResponse.json({ error: "Invalid listing ID" }, { status: 400 });
+  }
 
   const listing = db
     .prepare("SELECT * FROM listings WHERE id = ?")

--- a/app/app/api/listings/[id]/auto-discord/route.ts
+++ b/app/app/api/listings/[id]/auto-discord/route.ts
@@ -24,6 +24,9 @@ export async function GET(
 
   const { id } = await params;
   const listingId = parseInt(id, 10);
+  if (isNaN(listingId)) {
+    return NextResponse.json({ error: "Invalid listing ID" }, { status: 400 });
+  }
 
   const listing = db
     .prepare("SELECT * FROM listings WHERE id = ?")

--- a/app/app/api/listings/[id]/auto-telegram/route.ts
+++ b/app/app/api/listings/[id]/auto-telegram/route.ts
@@ -31,6 +31,9 @@ export async function GET(
 
   const { id } = await params;
   const listingId = parseInt(id, 10);
+  if (isNaN(listingId)) {
+    return NextResponse.json({ error: "Invalid listing ID" }, { status: 400 });
+  }
 
   const listing = db
     .prepare("SELECT * FROM listings WHERE id = ?")

--- a/app/app/api/listings/[id]/discord/route.ts
+++ b/app/app/api/listings/[id]/discord/route.ts
@@ -13,6 +13,9 @@ export async function POST(
 
   const { id } = await params;
   const listingId = parseInt(id, 10);
+  if (isNaN(listingId)) {
+    return NextResponse.json({ error: "Invalid listing ID" }, { status: 400 });
+  }
 
   const listing = db
     .prepare("SELECT * FROM listings WHERE id = ?")

--- a/app/app/api/listings/[id]/join/route.ts
+++ b/app/app/api/listings/[id]/join/route.ts
@@ -14,6 +14,9 @@ export async function POST(
 
   const { id } = await params;
   const listingId = parseInt(id, 10);
+  if (isNaN(listingId)) {
+    return NextResponse.json({ error: "Invalid listing ID" }, { status: 400 });
+  }
 
   const listing = db
     .prepare("SELECT * FROM listings WHERE id = ?")
@@ -21,6 +24,11 @@ export async function POST(
 
   if (!listing) {
     return NextResponse.json({ error: "Listing not found" }, { status: 404 });
+  }
+
+  // Author is already a member — don't allow re-joining
+  if (listing.author_id === session.userId) {
+    return NextResponse.json({ error: "You are the organizer of this group" }, { status: 400 });
   }
 
   if (listing.requires_approval) {
@@ -76,7 +84,7 @@ export async function POST(
   // Notify outside the transaction (fire-and-forget)
   notifyListingAuthor(listingId, session.displayName || "Someone");
 
-  if (result.count >= (listing.max_group_size as number)) {
+  if (result.count === (listing.max_group_size as number)) {
     notifyGroupFull(listingId);
   }
 

--- a/app/app/api/listings/[id]/route.ts
+++ b/app/app/api/listings/[id]/route.ts
@@ -9,6 +9,10 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
+  const listingId = parseInt(id, 10);
+  if (isNaN(listingId)) {
+    return NextResponse.json({ error: "Invalid listing ID" }, { status: 400 });
+  }
 
   const listing = db
     .prepare(
@@ -19,7 +23,7 @@ export async function GET(
       JOIN users u ON l.author_id = u.id
       WHERE l.id = ?`
     )
-    .get(id) as Record<string, unknown> | undefined;
+    .get(listingId) as Record<string, unknown> | undefined;
 
   if (!listing) {
     return NextResponse.json({ error: "Listing not found" }, { status: 404 });
@@ -33,7 +37,7 @@ export async function GET(
        WHERE lm.listing_id = ?
        ORDER BY lm.joined_at ASC`
     )
-    .all(id) as { id: number; display_name: string; bio: string; joined_at: string }[];
+    .all(listingId) as { id: number; display_name: string; bio: string; joined_at: string }[];
 
   const session = await getSession();
   const isMember = session.userId
@@ -59,7 +63,7 @@ export async function GET(
       .prepare(
         "SELECT status FROM listing_applications WHERE listing_id = ? AND user_id = ?"
       )
-      .get(id, session.userId) as { status: string } | undefined;
+      .get(listingId, session.userId) as { status: string } | undefined;
     if (app) {
       hasApplied = app.status === "pending";
       applicationStatus = app.status;
@@ -77,7 +81,7 @@ export async function GET(
          WHERE la.listing_id = ? AND la.status = 'pending'
          ORDER BY la.applied_at ASC`
       )
-      .all(id) as { application_id: number; id: number; display_name: string; bio: string; applied_at: string }[];
+      .all(listingId) as { application_id: number; id: number; display_name: string; bio: string; applied_at: string }[];
   }
 
   return NextResponse.json({

--- a/app/app/api/listings/[id]/telegram/route.ts
+++ b/app/app/api/listings/[id]/telegram/route.ts
@@ -13,6 +13,9 @@ export async function POST(
 
   const { id } = await params;
   const listingId = parseInt(id, 10);
+  if (isNaN(listingId)) {
+    return NextResponse.json({ error: "Invalid listing ID" }, { status: 400 });
+  }
 
   const listing = db
     .prepare("SELECT * FROM listings WHERE id = ?")

--- a/app/app/api/listings/create/route.ts
+++ b/app/app/api/listings/create/route.ts
@@ -46,6 +46,13 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    if (!startDate || !/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+      return NextResponse.json(
+        { error: "Invalid start date format (expected YYYY-MM-DD)" },
+        { status: 400 }
+      );
+    }
+
     const size = parseInt(maxGroupSize, 10);
     if (isNaN(size) || size < 2 || size > 20) {
       return NextResponse.json(

--- a/app/app/api/ratings/route.ts
+++ b/app/app/api/ratings/route.ts
@@ -151,6 +151,17 @@ export async function GET(req: NextRequest) {
     );
   }
 
+  // Verify the current user is a member of this listing
+  const isMember = db
+    .prepare("SELECT 1 FROM listing_members WHERE listing_id = ? AND user_id = ?")
+    .get(listingId, session.userId);
+  if (!isMember) {
+    return NextResponse.json(
+      { error: "You are not a member of this group" },
+      { status: 403 }
+    );
+  }
+
   // Ratings the current user has given in this listing
   const givenRatings = db
     .prepare(

--- a/app/app/api/telegram/webhook/route.ts
+++ b/app/app/api/telegram/webhook/route.ts
@@ -22,13 +22,14 @@ import { createNotification } from "@/lib/notifications";
  *    command in a group with a payload referencing a listing.
  */
 export async function POST(req: NextRequest) {
-  // Verify webhook secret if configured
+  // Verify webhook secret — fail closed if not configured
   const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
-  if (webhookSecret) {
-    const headerSecret = req.headers.get("X-Telegram-Bot-Api-Secret-Token");
-    if (headerSecret !== webhookSecret) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
-    }
+  if (!webhookSecret) {
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
+  }
+  const headerSecret = req.headers.get("X-Telegram-Bot-Api-Secret-Token");
+  if (headerSecret !== webhookSecret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
   }
 
   let update: Record<string, unknown>;

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -157,4 +157,12 @@ db.exec(`
   );
 `);
 
+// Performance indexes on high-frequency foreign key columns
+db.exec(`
+  CREATE INDEX IF NOT EXISTS idx_listing_members_user_id ON listing_members(user_id);
+  CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);
+  CREATE INDEX IF NOT EXISTS idx_ratings_rated_user_id ON ratings(rated_user_id);
+  CREATE INDEX IF NOT EXISTS idx_listings_author_id ON listings(author_id);
+`);
+
 export default db;


### PR DESCRIPTION
## Summary

Fixes 7 issues found during automated code review (3 critical, 4 important):

### Critical
- **Webhook auth fail-closed**: Telegram and Discord webhook endpoints now return 500 when secret env vars are unset, instead of silently skipping authentication (allowed unauthenticated DB writes)
- **parseInt NaN validation**: All `[id]` API routes now validate `parseInt` result for NaN before querying the database
- **Author self-join guard**: Listing authors (already auto-joined at creation) are now blocked from hitting `/join` again

### Important
- **startDate format validation**: Listing creation now enforces `YYYY-MM-DD` format (was storing arbitrary strings)
- **Group-full notification dedup**: Changed `>=` to `===` comparison to prevent duplicate notifications under concurrent joins
- **Ratings membership check**: `GET /api/ratings` now verifies the caller is a member of the requested listing
- **DB indexes**: Added indexes on `listing_members.user_id`, `notifications.user_id`, `ratings.rated_user_id`, `listings.author_id`

## Test plan
- [ ] Verify build passes
- [ ] Test webhook endpoints return 500 without secrets configured
- [ ] Test `/listings/abc` returns 400 (not 404 or 500)
- [ ] Test listing author cannot join their own listing
- [ ] Test creating listing with invalid date returns 400
- [ ] Test `GET /api/ratings` as non-member returns 403

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)