### PR TITLE
fix: rate limiting, navbar perf, error handling, DB indexes

### DIFF
--- a/app/app/api/auth/login/route.ts
+++ b/app/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import db from "@/lib/db";
 import { getSession } from "@/lib/session";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
   try {
@@ -11,6 +12,17 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { error: "Email and password are required" },
         { status: 400 }
+      );
+    }
+
+    // Rate limit: 5 login attempts per email+IP per 15 minutes
+    const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+    const rateLimitKey = `login:${ip}:${email.toLowerCase().trim()}`;
+    const { allowed, retryAfter } = checkRateLimit(rateLimitKey, 5);
+    if (!allowed) {
+      return NextResponse.json(
+        { error: "Too many login attempts. Please try again later." },
+        { status: 429, headers: { "Retry-After": String(retryAfter) } }
       );
     }
 

--- a/app/app/api/auth/me/route.ts
+++ b/app/app/api/auth/me/route.ts
@@ -20,12 +20,18 @@ export async function GET() {
     return NextResponse.json({ user: null });
   }
 
+  // Include unread notification count to avoid a second round-trip from the Navbar
+  const unread = db
+    .prepare("SELECT COUNT(*) as count FROM notifications WHERE user_id = ? AND is_read = 0")
+    .get(session.userId) as { count: number };
+
   return NextResponse.json({
     user: {
       id: user.id,
       email: user.email,
       displayName: user.display_name,
       bio: user.bio,
+      unreadNotificationCount: unread.count,
     },
   });
 }

--- a/app/app/api/auth/register/route.ts
+++ b/app/app/api/auth/register/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import db from "@/lib/db";
 import { getSession } from "@/lib/session";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
   try {
@@ -11,6 +12,16 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         { error: "Email, password, and display name are required" },
         { status: 400 }
+      );
+    }
+
+    // Rate limit: 3 registrations per IP per 15 minutes
+    const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+    const { allowed, retryAfter } = checkRateLimit(`register:${ip}`, 3);
+    if (!allowed) {
+      return NextResponse.json(
+        { error: "Too many registration attempts. Please try again later." },
+        { status: 429, headers: { "Retry-After": String(retryAfter) } }
       );
     }
 

--- a/app/app/listings/[id]/ListingDetail.tsx
+++ b/app/app/listings/[id]/ListingDetail.tsx
@@ -78,17 +78,26 @@ export default function ListingDetail() {
 
   const [notAvailable, setNotAvailable] = useState(false);
 
+  const [fetchError, setFetchError] = useState(false);
+
   const fetchListing = async () => {
-    const res = await fetch(`/api/listings/${id}`);
-    const data = await res.json();
-    if (res.ok && data.listing) {
-      setListing(data.listing);
-      setTelegramLink(data.listing.telegram_link || "");
-      setDiscordLink(data.listing.discord_link || "");
-    } else if (res.status === 404) {
-      setNotAvailable(true);
+    try {
+      const res = await fetch(`/api/listings/${id}`);
+      const data = await res.json();
+      if (res.ok && data.listing) {
+        setListing(data.listing);
+        setTelegramLink(data.listing.telegram_link || "");
+        setDiscordLink(data.listing.discord_link || "");
+      } else if (res.status === 404) {
+        setNotAvailable(true);
+      } else {
+        setFetchError(true);
+      }
+    } catch {
+      setFetchError(true);
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   };
 
   useEffect(() => {
@@ -335,6 +344,24 @@ export default function ListingDetail() {
     return (
       <div className="text-center py-16" style={{ color: "var(--color-text-secondary)" }}>
         <p style={{ fontFamily: "system-ui, sans-serif" }}>Loading...</p>
+      </div>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <div className="text-center py-16">
+        <h2 className="text-2xl mb-2">Something went wrong</h2>
+        <p style={{ color: "var(--color-text-secondary)", fontFamily: "system-ui, sans-serif" }}>
+          Failed to load this listing. Please try again.
+        </p>
+        <button
+          onClick={() => { setFetchError(false); setLoading(true); fetchListing(); }}
+          className="mt-4 px-4 py-2 rounded cursor-pointer"
+          style={{ background: "var(--color-accent)", color: "white", fontFamily: "system-ui, sans-serif" }}
+        >
+          Retry
+        </button>
       </div>
     );
   }

--- a/app/app/profile/page.tsx
+++ b/app/app/profile/page.tsx
@@ -77,6 +77,9 @@ export default function ProfilePage() {
         setBio(data.user.bio || "");
         setEmail(data.user.email);
         setLoading(false);
+      })
+      .catch(() => {
+        setLoading(false);
       });
   }, [router]);
 

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -22,11 +22,11 @@ export default function Navbar() {
       .then((data) => {
         if (data.user) {
           setUser(data.user);
-          // Fetch notification count
-          fetch("/api/notifications")
-            .then((r) => r.json())
-            .then((n) => setNotifCount(n.unreadCount || 0));
+          setNotifCount(data.user.unreadNotificationCount || 0);
         }
+      })
+      .catch(() => {
+        // Auth check failed — stay logged out
       });
   }, []);
 

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -163,6 +163,8 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);
   CREATE INDEX IF NOT EXISTS idx_ratings_rated_user_id ON ratings(rated_user_id);
   CREATE INDEX IF NOT EXISTS idx_listings_author_id ON listings(author_id);
+  CREATE INDEX IF NOT EXISTS idx_listing_applications_listing_status ON listing_applications(listing_id, status);
+  CREATE INDEX IF NOT EXISTS idx_notifications_user_unread ON notifications(user_id, is_read);
 `);
 
 export default db;

--- a/app/lib/rate-limit.ts
+++ b/app/lib/rate-limit.ts
@@ -1,0 +1,56 @@
+/**
+ * Simple in-memory rate limiter for auth endpoints.
+ * Uses a sliding window approach keyed by identifier (IP + route).
+ * Not shared across cluster workers — acceptable for SQLite single-process setup.
+ */
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+// Clean up expired entries every 5 minutes
+const CLEANUP_INTERVAL = 5 * 60 * 1000;
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of store) {
+    entry.timestamps = entry.timestamps.filter((t) => now - t < 15 * 60 * 1000);
+    if (entry.timestamps.length === 0) {
+      store.delete(key);
+    }
+  }
+}, CLEANUP_INTERVAL);
+
+/**
+ * Check if a request should be rate limited.
+ * @param key - Unique identifier (e.g., IP + email for login, IP for register)
+ * @param maxAttempts - Maximum attempts allowed in the window
+ * @param windowMs - Time window in milliseconds (default: 15 minutes)
+ * @returns Object with allowed boolean and retryAfter seconds (0 if allowed)
+ */
+export function checkRateLimit(
+  key: string,
+  maxAttempts: number = 5,
+  windowMs: number = 15 * 60 * 1000
+): { allowed: boolean; retryAfter: number } {
+  const now = Date.now();
+  let entry = store.get(key);
+
+  if (!entry) {
+    entry = { timestamps: [] };
+    store.set(key, entry);
+  }
+
+  // Remove expired timestamps
+  entry.timestamps = entry.timestamps.filter((t) => now - t < windowMs);
+
+  if (entry.timestamps.length >= maxAttempts) {
+    const oldestInWindow = entry.timestamps[0];
+    const retryAfter = Math.ceil((oldestInWindow + windowMs - now) / 1000);
+    return { allowed: false, retryAfter };
+  }
+
+  entry.timestamps.push(now);
+  return { allowed: true, retryAfter: 0 };
+}


### PR DESCRIPTION
## Summary
- **Rate limiting** on auth endpoints: login (5 attempts/15min per IP+email), register (3/15min per IP) with 429 responses
- **Navbar optimization**: merged unread notification count into `/api/auth/me` response, eliminating a second fetch on every page load
- **Error handling**: added try/catch + error state with retry button in ListingDetail; added .catch() to profile page auth check
- **DB indexes**: added composite indexes on `listing_applications(listing_id, status)` and `notifications(user_id, is_read)`

## Test plan
- [x] Build passes
- [x] Rate limiting verified: 6th login attempt returns HTTP 429
- [x] Production health check passes after deploy
- [x] Navbar still renders correctly (unread count from /api/auth/me)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)