### PR TITLE
feat: loading skeletons, error boundaries, improved error handling

### DIFF
--- a/app/app/error.tsx
+++ b/app/app/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="error-container">
+      <div
+        style={{
+          fontSize: "3rem",
+          marginBottom: "1rem",
+        }}
+      >
+        <svg
+          width="48"
+          height="48"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="var(--color-error)"
+          strokeWidth={1.5}
+          style={{ margin: "0 auto" }}
+        >
+          <circle cx={12} cy={12} r={10} />
+          <line x1={12} y1={8} x2={12} y2={12} />
+          <line x1={12} y1={16} x2={12.01} y2={16} />
+        </svg>
+      </div>
+      <h2>Something went wrong</h2>
+      <p>
+        {error.message || "An unexpected error occurred. Please try again."}
+      </p>
+      <div style={{ display: "flex", gap: "0.75rem", justifyContent: "center" }}>
+        <button onClick={reset} className="btn-primary">
+          Try again
+        </button>
+        <Link href="/" className="btn-secondary" style={{ textDecoration: "none" }}>
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -100,3 +100,57 @@ input, select, textarea {
   font-weight: 600;
   font-family: system-ui, -apple-system, sans-serif;
 }
+
+/* Focus-visible styles for keyboard navigation */
+.btn-primary:focus-visible,
+.btn-secondary:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}
+
+/* Skeleton loading animation */
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 0.8; }
+}
+
+.skeleton {
+  background-color: var(--color-border);
+  border-radius: 0.375rem;
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+.skeleton-text {
+  height: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.skeleton-heading {
+  height: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+/* Error boundary styles */
+.error-container {
+  text-align: center;
+  padding: 4rem 1rem;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.error-container h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: var(--color-text);
+}
+
+.error-container p {
+  color: var(--color-text-secondary);
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+}

--- a/app/app/listings/[id]/error.tsx
+++ b/app/app/listings/[id]/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+
+export default function ListingError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="error-container">
+      <svg
+        width="48"
+        height="48"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="var(--color-text-secondary)"
+        strokeWidth={1.5}
+        style={{ margin: "0 auto 1rem" }}
+      >
+        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+        <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+        <line x1={12} y1={8} x2={12} y2={12} />
+        <line x1={12} y1={16} x2={12.01} y2={16} />
+      </svg>
+      <h2>Could not load listing</h2>
+      <p>
+        {error.message || "This listing may not exist or could not be loaded right now."}
+      </p>
+      <div style={{ display: "flex", gap: "0.75rem", justifyContent: "center" }}>
+        <button onClick={reset} className="btn-primary">
+          Try again
+        </button>
+        <Link href="/" className="btn-secondary" style={{ textDecoration: "none" }}>
+          Browse listings
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/app/listings/[id]/loading.tsx
+++ b/app/app/listings/[id]/loading.tsx
@@ -1,0 +1,29 @@
+export default function ListingLoading() {
+  return (
+    <div style={{ maxWidth: "48rem", margin: "0 auto" }}>
+      <div className="skeleton skeleton-text" style={{ width: "5rem", marginBottom: "1.5rem" }} />
+      <div className="card">
+        <div className="flex gap-6" style={{ flexWrap: "wrap" }}>
+          <div className="skeleton" style={{ width: "8rem", height: "12rem", flexShrink: 0 }} />
+          <div className="flex-1" style={{ minWidth: "16rem" }}>
+            <div className="skeleton skeleton-heading" style={{ width: "70%", height: "1.75rem" }} />
+            <div className="skeleton skeleton-text" style={{ width: "40%" }} />
+            <div className="skeleton skeleton-text" style={{ width: "50%", marginTop: "1rem" }} />
+            <div className="flex gap-2 mt-3">
+              <div className="skeleton" style={{ width: "5rem", height: "1.5rem", borderRadius: "9999px" }} />
+              <div className="skeleton" style={{ width: "4rem", height: "1.5rem", borderRadius: "9999px" }} />
+              <div className="skeleton" style={{ width: "6rem", height: "1.5rem", borderRadius: "9999px" }} />
+            </div>
+          </div>
+        </div>
+        <div style={{ marginTop: "1.5rem", borderTop: "1px solid var(--color-border)", paddingTop: "1.5rem" }}>
+          <div className="skeleton skeleton-heading" style={{ width: "6rem" }} />
+          <div className="flex gap-2 mt-2">
+            <div className="skeleton" style={{ width: "2rem", height: "2rem", borderRadius: "50%" }} />
+            <div className="skeleton" style={{ width: "2rem", height: "2rem", borderRadius: "50%" }} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/loading.tsx
+++ b/app/app/loading.tsx
@@ -1,0 +1,37 @@
+export default function Loading() {
+  return (
+    <div>
+      <div className="text-center mb-8 mt-4">
+        <div className="skeleton skeleton-heading mx-auto" style={{ width: "60%", height: "2rem" }} />
+        <div className="skeleton skeleton-text mx-auto" style={{ width: "80%", maxWidth: "32rem" }} />
+      </div>
+
+      {/* Search bar skeleton */}
+      <div className="mb-6">
+        <div className="flex gap-3 items-center">
+          <div className="flex-1 skeleton" style={{ height: "2.75rem" }} />
+          <div className="skeleton" style={{ width: "6rem", height: "2.75rem" }} />
+        </div>
+      </div>
+
+      {/* Listing card skeletons */}
+      <div className="skeleton skeleton-text" style={{ width: "8rem", marginBottom: "0.75rem" }} />
+      <div className="grid gap-4">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="card flex gap-4">
+            <div className="skeleton" style={{ width: "4rem", height: "6rem", flexShrink: 0 }} />
+            <div className="flex-1">
+              <div className="skeleton skeleton-heading" style={{ width: "60%" }} />
+              <div className="skeleton skeleton-text" style={{ width: "40%" }} />
+              <div className="flex gap-2 mt-2">
+                <div className="skeleton" style={{ width: "5rem", height: "1.5rem", borderRadius: "9999px" }} />
+                <div className="skeleton" style={{ width: "4rem", height: "1.5rem", borderRadius: "9999px" }} />
+                <div className="skeleton" style={{ width: "5.5rem", height: "1.5rem", borderRadius: "9999px" }} />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/app/notifications/error.tsx
+++ b/app/app/notifications/error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+
+export default function NotificationsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="error-container">
+      <svg
+        width="48"
+        height="48"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="var(--color-text-secondary)"
+        strokeWidth={1.5}
+        style={{ margin: "0 auto 1rem" }}
+      >
+        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+        <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+      </svg>
+      <h2>Could not load notifications</h2>
+      <p>
+        {error.message || "There was a problem loading your notifications."}
+      </p>
+      <div style={{ display: "flex", gap: "0.75rem", justifyContent: "center" }}>
+        <button onClick={reset} className="btn-primary">
+          Try again
+        </button>
+        <Link href="/" className="btn-secondary" style={{ textDecoration: "none" }}>
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/app/notifications/loading.tsx
+++ b/app/app/notifications/loading.tsx
@@ -1,0 +1,20 @@
+export default function NotificationsLoading() {
+  return (
+    <div style={{ maxWidth: "40rem", margin: "0 auto" }}>
+      <div className="skeleton skeleton-heading" style={{ width: "10rem", height: "1.75rem", marginBottom: "1.5rem" }} />
+      <div className="grid gap-3">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="card" style={{ padding: "1rem 1.25rem" }}>
+            <div className="flex gap-3 items-start">
+              <div className="skeleton" style={{ width: "2rem", height: "2rem", borderRadius: "50%", flexShrink: 0 }} />
+              <div className="flex-1">
+                <div className="skeleton skeleton-text" style={{ width: "80%" }} />
+                <div className="skeleton skeleton-text" style={{ width: "30%", height: "0.75rem" }} />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -23,6 +23,7 @@ interface Listing {
 export default function HomePage() {
   const [listings, setListings] = useState<Listing[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   // Search & filter state
   const [searchQuery, setSearchQuery] = useState("");
@@ -46,12 +47,19 @@ export default function HomePage() {
 
       const qs = params.toString();
       fetch(`/api/listings${qs ? `?${qs}` : ""}`)
-        .then((r) => r.json())
+        .then((r) => {
+          if (!r.ok) throw new Error("Failed to load listings");
+          return r.json();
+        })
         .then((data) => {
           setListings(data.listings || []);
+          setError(null);
           setLoading(false);
         })
-        .catch(() => setLoading(false));
+        .catch((err) => {
+          setError(err.message || "Could not load listings. Please try again.");
+          setLoading(false);
+        });
     },
     []
   );
@@ -327,13 +335,80 @@ export default function HomePage() {
 
       {/* Results */}
       {loading ? (
-        <div
-          className="text-center py-16"
-          style={{ color: "var(--color-text-secondary)" }}
-        >
-          <p style={{ fontFamily: "system-ui, sans-serif" }}>
-            Loading listings...
+        <div className="grid gap-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="card flex gap-4">
+              <div
+                className="skeleton"
+                style={{ width: "4rem", height: "6rem", flexShrink: 0 }}
+              />
+              <div className="flex-1">
+                <div
+                  className="skeleton skeleton-heading"
+                  style={{ width: `${60 - i * 5}%` }}
+                />
+                <div
+                  className="skeleton skeleton-text"
+                  style={{ width: `${45 - i * 5}%` }}
+                />
+                <div className="flex gap-2 mt-2">
+                  <div
+                    className="skeleton"
+                    style={{
+                      width: "5rem",
+                      height: "1.5rem",
+                      borderRadius: "9999px",
+                    }}
+                  />
+                  <div
+                    className="skeleton"
+                    style={{
+                      width: "4rem",
+                      height: "1.5rem",
+                      borderRadius: "9999px",
+                    }}
+                  />
+                  <div
+                    className="skeleton"
+                    style={{
+                      width: "5.5rem",
+                      height: "1.5rem",
+                      borderRadius: "9999px",
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : error ? (
+        <div className="text-center py-16">
+          <svg
+            width="40"
+            height="40"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--color-error)"
+            strokeWidth={1.5}
+            style={{ margin: "0 auto 0.75rem" }}
+          >
+            <circle cx={12} cy={12} r={10} />
+            <line x1={12} y1={8} x2={12} y2={12} />
+            <line x1={12} y1={16} x2={12.01} y2={16} />
+          </svg>
+          <p
+            className="text-lg mb-2"
+            style={{ color: "var(--color-text)", fontFamily: "system-ui, sans-serif" }}
+          >
+            {error}
           </p>
+          <button
+            onClick={() => fetchListings(searchQuery, meetingFormat, sort, readingPace, startDateFrom)}
+            className="btn-primary"
+            style={{ marginTop: "0.75rem" }}
+          >
+            Try again
+          </button>
         </div>
       ) : listings.length === 0 ? (
         <div className="text-center py-16">

--- a/app/app/profile/error.tsx
+++ b/app/app/profile/error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+
+export default function ProfileError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="error-container">
+      <svg
+        width="48"
+        height="48"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="var(--color-text-secondary)"
+        strokeWidth={1.5}
+        style={{ margin: "0 auto 1rem" }}
+      >
+        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+        <circle cx={12} cy={7} r={4} />
+      </svg>
+      <h2>Could not load profile</h2>
+      <p>
+        {error.message || "There was a problem loading your profile. Please try again."}
+      </p>
+      <div style={{ display: "flex", gap: "0.75rem", justifyContent: "center" }}>
+        <button onClick={reset} className="btn-primary">
+          Try again
+        </button>
+        <Link href="/" className="btn-secondary" style={{ textDecoration: "none" }}>
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/app/profile/loading.tsx
+++ b/app/app/profile/loading.tsx
@@ -1,0 +1,31 @@
+export default function ProfileLoading() {
+  return (
+    <div style={{ maxWidth: "40rem", margin: "0 auto" }}>
+      <div className="skeleton skeleton-heading" style={{ width: "8rem", height: "1.75rem", marginBottom: "1.5rem" }} />
+      <div className="card mb-6">
+        <div className="flex items-center gap-4 mb-4">
+          <div className="skeleton" style={{ width: "4rem", height: "4rem", borderRadius: "50%" }} />
+          <div className="flex-1">
+            <div className="skeleton skeleton-heading" style={{ width: "40%" }} />
+            <div className="skeleton skeleton-text" style={{ width: "60%" }} />
+          </div>
+        </div>
+        <div className="skeleton skeleton-text" style={{ width: "100%" }} />
+        <div className="skeleton skeleton-text" style={{ width: "80%" }} />
+      </div>
+
+      <div className="skeleton skeleton-heading" style={{ width: "10rem", marginBottom: "1rem" }} />
+      <div className="grid gap-3">
+        {[1, 2].map((i) => (
+          <div key={i} className="card flex gap-3">
+            <div className="skeleton" style={{ width: "3rem", height: "4.5rem", flexShrink: 0 }} />
+            <div className="flex-1">
+              <div className="skeleton skeleton-heading" style={{ width: "50%" }} />
+              <div className="skeleton skeleton-text" style={{ width: "35%" }} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Added animated **skeleton loading UI** to all major routes (home, listing detail, profile, notifications) replacing plain "Loading..." text
- Added **error boundary** (`error.tsx`) components to all routes with retry buttons and navigation links for graceful error recovery
- Fixed **silent catch block** on homepage listing fetch — now displays user-facing error message with retry button
- Added **focus-visible styles** for buttons and links (keyboard navigation accessibility)

## Changes
| File | Change |
|------|--------|
| `app/globals.css` | Skeleton animation, error-container styles, focus-visible styles |
| `app/loading.tsx` | Root route skeleton (search bar + listing cards) |
| `app/error.tsx` | Root error boundary with retry + home link |
| `app/listings/[id]/loading.tsx` | Listing detail skeleton |
| `app/listings/[id]/error.tsx` | Listing error boundary |
| `app/profile/loading.tsx` | Profile skeleton |
| `app/profile/error.tsx` | Profile error boundary |
| `app/notifications/loading.tsx` | Notifications skeleton |
| `app/notifications/error.tsx` | Notifications error boundary |
| `app/page.tsx` | Error state + skeleton loading for client-side fetch |

## Test plan
- [ ] Navigate between routes and verify skeleton loading appears during transitions
- [ ] Verify error boundaries display correctly (can test by temporarily breaking an API route)
- [ ] Verify "Try again" buttons work on error pages
- [ ] Verify focus-visible outlines show when tabbing through buttons/links
- [ ] Build passes: `npm run build` ✅

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)