### PR TITLE
fix: security and robustness issues from code review

### DIFF
--- a/app/app/api/listings/[id]/applications/route.ts
+++ b/app/app/api/listings/[id]/applications/route.ts
@@ -80,33 +80,43 @@ export async function PATCH(
 
       // Check if group is now full
       const newCount = count + 1;
+      let rejectedApps: { id: number; user_id: number }[] = [];
       if (newCount >= (listing.max_group_size as number)) {
         db.prepare("UPDATE listings SET is_full = 1 WHERE id = ?").run(listingId);
-        return { isFull: true };
-      }
-      return { isFull: false };
-    });
 
-    try {
-      const result = approveTransaction();
-
-      notifyApplicationDecision(applicantUserId, listingId, "approved");
-
-      if (result.isFull) {
-        notifyGroupFull(listingId);
-        // Reject remaining pending applications
-        const pendingApps = db
+        // Reject remaining pending applications inside the transaction
+        rejectedApps = db
           .prepare(
             "SELECT id, user_id FROM listing_applications WHERE listing_id = ? AND status = 'pending'"
           )
           .all(listingId) as { id: number; user_id: number }[];
 
-        for (const app of pendingApps) {
+        for (const app of rejectedApps) {
           db.prepare(
             "UPDATE listing_applications SET status = 'rejected', decided_at = datetime('now') WHERE id = ?"
           ).run(app.id);
-          notifyApplicationDecision(app.user_id, listingId, "rejected");
         }
+
+        return { isFull: true, rejectedApps };
+      }
+      return { isFull: false, rejectedApps };
+    });
+
+    try {
+      const result = approveTransaction();
+
+      // Send notifications outside the transaction (non-critical)
+      try {
+        notifyApplicationDecision(applicantUserId, listingId, "approved");
+
+        if (result.isFull) {
+          notifyGroupFull(listingId);
+          for (const app of result.rejectedApps) {
+            notifyApplicationDecision(app.user_id, listingId, "rejected");
+          }
+        }
+      } catch (notifErr) {
+        console.error("Notification error (approval succeeded):", notifErr);
       }
 
       return NextResponse.json({ ok: true });

--- a/app/app/api/listings/[id]/apply/route.ts
+++ b/app/app/api/listings/[id]/apply/route.ts
@@ -26,6 +26,13 @@ export async function POST(
     return NextResponse.json({ error: "Listing not found" }, { status: 404 });
   }
 
+  if (listing.author_id === session.userId) {
+    return NextResponse.json(
+      { error: "You cannot apply to your own listing" },
+      { status: 400 }
+    );
+  }
+
   if (!listing.requires_approval) {
     return NextResponse.json(
       { error: "This group does not require approval. Join directly." },

--- a/app/app/api/listings/create/route.ts
+++ b/app/app/api/listings/create/route.ts
@@ -65,6 +65,13 @@ export async function POST(req: NextRequest) {
       ? platformPreference
       : "telegram";
 
+    // Validate book cover URL — only allow Open Library covers to prevent SSRF/tracking
+    const sanitizedCoverUrl =
+      bookCoverUrl && typeof bookCoverUrl === "string" &&
+      bookCoverUrl.startsWith("https://covers.openlibrary.org/")
+        ? bookCoverUrl
+        : "";
+
     const result = db
       .prepare(
         `INSERT INTO listings (author_id, book_title, book_author, book_cover_url, book_olid, language, reading_pace, start_date, meeting_format, max_group_size, requires_approval, platform_preference)
@@ -74,7 +81,7 @@ export async function POST(req: NextRequest) {
         session.userId,
         bookTitle.trim(),
         bookAuthor.trim(),
-        bookCoverUrl || "",
+        sanitizedCoverUrl,
         bookOlid || "",
         language || "English",
         readingPace.trim(),

--- a/app/app/api/listings/route.ts
+++ b/app/app/api/listings/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
   const conditions: string[] = ["l.is_full = 0"];
   const params: (string | number)[] = [];
 
-  if (q) {
+  if (q && q.length <= 300) {
     conditions.push("(l.book_title LIKE ? OR l.book_author LIKE ?)");
     params.push(`%${q}%`, `%${q}%`);
   }
@@ -23,7 +23,7 @@ export async function GET(request: NextRequest) {
     params.push(meetingFormat);
   }
 
-  if (readingPace) {
+  if (readingPace && readingPace.length <= 200) {
     conditions.push("l.reading_pace LIKE ?");
     params.push(`%${readingPace}%`);
   }

--- a/app/app/api/ratings/route.ts
+++ b/app/app/api/ratings/route.ts
@@ -143,10 +143,17 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  const listingId = req.nextUrl.searchParams.get("listingId");
-  if (!listingId) {
+  const listingIdParam = req.nextUrl.searchParams.get("listingId");
+  if (!listingIdParam) {
     return NextResponse.json(
       { error: "listingId parameter required" },
+      { status: 400 }
+    );
+  }
+  const listingId = parseInt(listingIdParam, 10);
+  if (isNaN(listingId)) {
+    return NextResponse.json(
+      { error: "Invalid listingId" },
       { status: 400 }
     );
   }

--- a/app/app/api/telegram/webhook/route.ts
+++ b/app/app/api/telegram/webhook/route.ts
@@ -171,34 +171,52 @@ async function handleMessage(message: TelegramMessage) {
   }
 
   // Handle /link command — allow manual linking
+  // Security: only show listings authored by a Bookmate user linked to this Telegram user
   if (text === "/link") {
-    // Find the most recent full listing without a telegram link
-    // that was authored by someone (we can't verify Telegram user = Bookmate user
-    // without account linking, so we just report available listings)
+    const telegramUserId = message.from?.id;
+    if (!telegramUserId) {
+      await sendMessage(message.chat.id, "Could not identify the sender.");
+      return;
+    }
+
+    // Look up the Bookmate user linked to this Telegram user
+    const linkedUser = db
+      .prepare("SELECT user_id FROM telegram_user_links WHERE telegram_user_id = ?")
+      .get(telegramUserId) as { user_id: number } | undefined;
+
+    if (!linkedUser) {
+      await sendMessage(
+        message.chat.id,
+        "Your Telegram account is not linked to a Bookmate account. " +
+          "Please use the Telegram setup link from your Bookmate listing page to link your account first."
+      );
+      return;
+    }
+
+    // Only show unlinked listings authored by this verified user
     const unlinkedListings = db
       .prepare(
         `SELECT id, book_title FROM listings
          WHERE is_full = 1 AND (telegram_link = '' OR telegram_link IS NULL)
          AND telegram_chat_id IS NULL
+         AND author_id = ?
          ORDER BY created_at DESC LIMIT 5`
       )
-      .all() as { id: number; book_title: string }[];
+      .all(linkedUser.user_id) as { id: number; book_title: string }[];
 
     if (unlinkedListings.length === 0) {
       await sendMessage(
         message.chat.id,
-        "No unlinked reading groups found. The group may already be set up!"
+        "No unlinked reading groups found for your account. The group may already be set up!"
       );
       return;
     }
 
     if (unlinkedListings.length === 1) {
-      // Auto-link the only available listing
       await linkTelegramToListing(unlinkedListings[0].id, message.chat.id);
       return;
     }
 
-    // Show options
     const listText = unlinkedListings
       .map((l) => `  /link_${l.id} — "${l.book_title}"`)
       .join("\n");
@@ -209,10 +227,42 @@ async function handleMessage(message: TelegramMessage) {
     return;
   }
 
-  // Handle /link_ID command
+  // Handle /link_ID command — require verified ownership
   const linkMatch = text.match(/^\/link_(\d+)$/);
   if (linkMatch) {
+    const telegramUserId = message.from?.id;
+    if (!telegramUserId) {
+      await sendMessage(message.chat.id, "Could not identify the sender.");
+      return;
+    }
+
+    const linkedUser = db
+      .prepare("SELECT user_id FROM telegram_user_links WHERE telegram_user_id = ?")
+      .get(telegramUserId) as { user_id: number } | undefined;
+
+    if (!linkedUser) {
+      await sendMessage(
+        message.chat.id,
+        "Your Telegram account is not linked to a Bookmate account."
+      );
+      return;
+    }
+
     const listingId = parseInt(linkMatch[1], 10);
+
+    // Verify this user is the listing author
+    const listing = db
+      .prepare("SELECT author_id FROM listings WHERE id = ?")
+      .get(listingId) as { author_id: number } | undefined;
+
+    if (!listing || listing.author_id !== linkedUser.user_id) {
+      await sendMessage(
+        message.chat.id,
+        "You can only link Telegram groups to your own Bookmate listings."
+      );
+      return;
+    }
+
     await linkTelegramToListing(listingId, message.chat.id);
   }
 }

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -138,6 +138,15 @@ db.exec(`
     chat_title TEXT DEFAULT '',
     created_at TEXT DEFAULT (datetime('now'))
   );
+
+  CREATE TABLE IF NOT EXISTS telegram_user_links (
+    user_id INTEGER NOT NULL,
+    telegram_user_id INTEGER NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (user_id),
+    UNIQUE (telegram_user_id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+  );
 `);
 
 // Rating and Reputation system


### PR DESCRIPTION
## Summary
- **Telegram webhook hardening**: `/link` and `/link_ID` commands now require verified Bookmate↔Telegram account linking via new `telegram_user_links` table, preventing any Telegram user from hijacking a listing's chat
- **Auth guards**: Block authors from applying to their own listings; validate `book_cover_url` origin to prevent SSRF/tracking pixels
- **Data integrity**: Move pending-application rejection inside DB transaction; parse `listingId` as integer in ratings GET; add length caps on search parameters
- **Error resilience**: Notification failures no longer mask successful DB transactions

## Test plan
- [ ] Verify production health after deploy (done: HTTP 200, health OK)
- [ ] Verify build passes with no new lint errors
- [ ] Test listing creation still works with valid cover URLs
- [ ] Test `/link` command in Telegram requires account linking

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)