### PR TITLE
feat: add mobile responsive design across all pages

### DIFF
--- a/app/app/auth/login/page.tsx
+++ b/app/app/auth/login/page.tsx
@@ -39,7 +39,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="max-w-md mx-auto mt-12">
+    <div className="max-w-md mx-auto mt-4 sm:mt-12">
       <div className="card">
         <h1 className="text-2xl mb-1">Welcome back</h1>
         <p

--- a/app/app/auth/register/page.tsx
+++ b/app/app/auth/register/page.tsx
@@ -40,7 +40,7 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="max-w-md mx-auto mt-12">
+    <div className="max-w-md mx-auto mt-4 sm:mt-12">
       <div className="card">
         <h1 className="text-2xl mb-1">Create an account</h1>
         <p

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
           Skip to content
         </a>
         <Navbar />
-        <main id="main-content" className="max-w-5xl mx-auto px-4 py-8">{children}</main>
+        <main id="main-content" className="max-w-5xl mx-auto px-3 sm:px-4 py-4 sm:py-8">{children}</main>
       </body>
     </html>
   );

--- a/app/app/listings/[id]/ListingDetail.tsx
+++ b/app/app/listings/[id]/ListingDetail.tsx
@@ -413,17 +413,17 @@ export default function ListingDetail() {
       )}
 
       <div className="card mb-6">
-        <div className="flex gap-5">
+        <div className="flex flex-col sm:flex-row gap-4 sm:gap-5">
           {listing.book_cover_url ? (
             <img
               src={listing.book_cover_url}
               alt={listing.book_title}
-              className="w-24 h-36 object-cover rounded-lg shadow-sm"
+              className="w-20 h-28 sm:w-24 sm:h-36 object-cover rounded-lg shadow-sm"
               style={{ flexShrink: 0 }}
             />
           ) : (
             <div
-              className="w-24 h-36 rounded-lg flex items-center justify-center text-4xl"
+              className="w-20 h-28 sm:w-24 sm:h-36 rounded-lg flex items-center justify-center text-3xl sm:text-4xl"
               style={{
                 backgroundColor: "var(--color-border)",
                 flexShrink: 0,
@@ -434,7 +434,7 @@ export default function ListingDetail() {
           )}
 
           <div className="flex-1">
-            <h1 className="text-2xl mb-1">{listing.book_title}</h1>
+            <h1 className="text-xl sm:text-2xl mb-1">{listing.book_title}</h1>
             <p
               className="text-sm mb-4"
               style={{
@@ -460,7 +460,7 @@ export default function ListingDetail() {
             ) : null}
 
             <div
-              className="grid grid-cols-2 gap-y-2 gap-x-6 text-sm"
+              className="grid grid-cols-2 gap-y-2 gap-x-4 sm:gap-x-6 text-sm"
               style={{ fontFamily: "system-ui, sans-serif" }}
             >
               <div>
@@ -500,7 +500,7 @@ export default function ListingDetail() {
         </div>
 
         <div
-          className="mt-5 pt-4 flex items-center justify-between"
+          className="mt-4 sm:mt-5 pt-4 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3"
           style={{ borderTop: "1px solid var(--color-border)" }}
         >
           <div style={{ fontFamily: "system-ui, sans-serif" }}>

--- a/app/app/listings/create/page.tsx
+++ b/app/app/listings/create/page.tsx
@@ -78,9 +78,9 @@ export default function CreateListingPage() {
 
   return (
     <div className="max-w-lg mx-auto">
-      <h1 className="text-3xl mb-2">Start a reading group</h1>
+      <h1 className="text-2xl sm:text-3xl mb-2">Start a reading group</h1>
       <p
-        className="mb-8"
+        className="mb-6 sm:mb-8"
         style={{
           color: "var(--color-text-secondary)",
           fontFamily: "system-ui, sans-serif",

--- a/app/app/notifications/page.tsx
+++ b/app/app/notifications/page.tsx
@@ -42,7 +42,7 @@ export default function NotificationsPage() {
 
   return (
     <div className="max-w-2xl mx-auto">
-      <h1 className="text-3xl mb-6">Notifications</h1>
+      <h1 className="text-2xl sm:text-3xl mb-4 sm:mb-6">Notifications</h1>
 
       {notifications.length === 0 ? (
         <div className="text-center py-12">

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -121,12 +121,12 @@ export default function HomePage() {
 
   return (
     <div>
-      <div className="text-center mb-8 mt-4">
-        <h1 className="text-4xl mb-3" style={{ color: "var(--color-text)" }}>
+      <div className="text-center mb-6 sm:mb-8 mt-2 sm:mt-4">
+        <h1 className="text-2xl sm:text-4xl mb-2 sm:mb-3" style={{ color: "var(--color-text)" }}>
           Find your reading companion
         </h1>
         <p
-          className="text-lg max-w-xl mx-auto"
+          className="text-sm sm:text-lg max-w-xl mx-auto"
           style={{
             color: "var(--color-text-secondary)",
             fontFamily: "system-ui, sans-serif",
@@ -222,10 +222,10 @@ export default function HomePage() {
             style={{ padding: "1rem 1.25rem" }}
           >
             <div
-              className="flex flex-wrap gap-4 items-end"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 items-end"
               style={{ fontFamily: "system-ui, sans-serif" }}
             >
-              <div style={{ minWidth: "160px" }}>
+              <div>
                 <label
                   className="text-xs font-semibold mb-1 block"
                   style={{
@@ -249,7 +249,7 @@ export default function HomePage() {
                 </select>
               </div>
 
-              <div style={{ minWidth: "160px" }}>
+              <div>
                 <label
                   className="text-xs font-semibold mb-1 block"
                   style={{
@@ -274,7 +274,7 @@ export default function HomePage() {
                 </select>
               </div>
 
-              <div style={{ minWidth: "160px" }}>
+              <div>
                 <label
                   className="text-xs font-semibold mb-1 block"
                   style={{
@@ -294,7 +294,7 @@ export default function HomePage() {
                 />
               </div>
 
-              <div style={{ minWidth: "160px" }}>
+              <div>
                 <label
                   className="text-xs font-semibold mb-1 block"
                   style={{

--- a/app/app/profile/page.tsx
+++ b/app/app/profile/page.tsx
@@ -198,12 +198,12 @@ export default function ProfilePage() {
 
   return (
     <div className="max-w-2xl mx-auto">
-      <h1 className="text-3xl mb-6">Your Profile</h1>
+      <h1 className="text-2xl sm:text-3xl mb-4 sm:mb-6">Your Profile</h1>
 
       {/* Tabs */}
       <div
-        className="flex gap-1 mb-6 p-1 rounded-lg"
-        style={{ backgroundColor: "var(--color-border)" }}
+        className="flex gap-1 mb-4 sm:mb-6 p-1 rounded-lg overflow-x-auto"
+        style={{ backgroundColor: "var(--color-border)", WebkitOverflowScrolling: "touch" }}
         role="tablist"
         aria-label="Profile sections"
       >
@@ -215,7 +215,7 @@ export default function ProfilePage() {
             aria-selected={activeTab === tab.key}
             aria-controls={`tabpanel-${tab.key}`}
             onClick={() => setActiveTab(tab.key)}
-            className="flex-1 py-2 px-4 rounded-md text-sm font-semibold transition-all"
+            className="flex-1 py-2 px-2 sm:px-4 rounded-md text-xs sm:text-sm font-semibold transition-all whitespace-nowrap"
             style={{
               fontFamily: "system-ui, sans-serif",
               backgroundColor: activeTab === tab.key ? "var(--color-surface)" : "transparent",
@@ -370,10 +370,10 @@ export default function ProfilePage() {
             <>
               {/* Score Overview */}
               <div className="card">
-                <div className="flex items-center gap-6">
+                <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-6">
                   <div className="text-center">
                     <div
-                      className="text-4xl font-bold"
+                      className="text-3xl sm:text-4xl font-bold"
                       style={{ color: reputation.averageScore >= 4 ? "var(--color-success)" : reputation.averageScore >= 3 ? "#f59e0b" : "var(--color-text)" }}
                     >
                       {reputation.totalRatings > 0 ? reputation.averageScore : "--"}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 
 interface User {
@@ -14,7 +14,9 @@ export default function Navbar() {
   const [user, setUser] = useState<User | null>(null);
   const [notifCount, setNotifCount] = useState(0);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const router = useRouter();
+  const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     fetch("/api/auth/me")
@@ -30,10 +32,28 @@ export default function Navbar() {
       });
   }, []);
 
+  // Close menus on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Close mobile menu on route change
+  useEffect(() => {
+    setMobileMenuOpen(false);
+    setMenuOpen(false);
+  }, []);
+
   const handleLogout = async () => {
     await fetch("/api/auth/logout", { method: "POST" });
     setUser(null);
     setMenuOpen(false);
+    setMobileMenuOpen(false);
     router.push("/");
     router.refresh();
   };
@@ -46,16 +66,18 @@ export default function Navbar() {
         backgroundColor: "var(--color-bg)",
       }}
     >
-      <div className="max-w-5xl mx-auto px-4 h-16 flex items-center justify-between">
+      <div className="max-w-5xl mx-auto px-3 sm:px-4 h-14 sm:h-16 flex items-center justify-between">
         <Link
           href="/"
-          className="text-xl font-bold"
+          className="text-lg sm:text-xl font-bold"
           style={{ color: "var(--color-accent)", letterSpacing: "-0.03em" }}
+          onClick={() => setMobileMenuOpen(false)}
         >
           bookmate
         </Link>
 
-        <div className="flex items-center gap-4">
+        {/* Desktop nav */}
+        <div className="hidden sm:flex items-center gap-4">
           {user ? (
             <>
               <Link
@@ -66,7 +88,7 @@ export default function Navbar() {
                 + New Listing
               </Link>
 
-              <div className="relative">
+              <div className="relative" ref={menuRef}>
                 <button
                   onClick={() => setMenuOpen(!menuOpen)}
                   className="flex items-center gap-2 cursor-pointer"
@@ -171,7 +193,142 @@ export default function Navbar() {
             </div>
           )}
         </div>
+
+        {/* Mobile hamburger */}
+        <div className="flex sm:hidden items-center gap-2">
+          {user && notifCount > 0 && (
+            <Link
+              href="/notifications"
+              className="badge text-white"
+              style={{ backgroundColor: "var(--color-error)", fontSize: "0.65rem" }}
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              {notifCount}
+            </Link>
+          )}
+          <button
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            className="p-2 cursor-pointer"
+            aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={mobileMenuOpen}
+            style={{ background: "none", border: "none" }}
+          >
+            {mobileMenuOpen ? (
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--color-text)" strokeWidth={2} strokeLinecap="round">
+                <line x1={6} y1={6} x2={18} y2={18} />
+                <line x1={6} y1={18} x2={18} y2={6} />
+              </svg>
+            ) : (
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--color-text)" strokeWidth={2} strokeLinecap="round">
+                <line x1={3} y1={6} x2={21} y2={6} />
+                <line x1={3} y1={12} x2={21} y2={12} />
+                <line x1={3} y1={18} x2={21} y2={18} />
+              </svg>
+            )}
+          </button>
+        </div>
       </div>
+
+      {/* Mobile menu panel */}
+      {mobileMenuOpen && (
+        <div
+          className="sm:hidden border-t"
+          style={{
+            borderColor: "var(--color-border)",
+            backgroundColor: "var(--color-bg)",
+          }}
+        >
+          <div className="px-4 py-3 space-y-1">
+            {user ? (
+              <>
+                <div
+                  className="px-3 py-2 text-sm font-bold flex items-center gap-2"
+                  style={{ fontFamily: "system-ui, sans-serif" }}
+                >
+                  <div
+                    className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold text-white"
+                    style={{ backgroundColor: "var(--color-accent)" }}
+                  >
+                    {user.displayName.charAt(0).toUpperCase()}
+                  </div>
+                  {user.displayName}
+                </div>
+                <Link
+                  href="/listings/create"
+                  className="block px-3 py-2.5 text-sm font-semibold rounded-lg"
+                  style={{
+                    backgroundColor: "var(--color-accent)",
+                    color: "white",
+                    textAlign: "center",
+                    fontFamily: "system-ui, sans-serif",
+                  }}
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  + New Listing
+                </Link>
+                <Link
+                  href="/profile"
+                  className="block px-3 py-2.5 text-sm rounded-lg"
+                  style={{ fontFamily: "system-ui, sans-serif", color: "var(--color-text)" }}
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  Profile
+                </Link>
+                <Link
+                  href="/notifications"
+                  className="block px-3 py-2.5 text-sm rounded-lg"
+                  style={{ fontFamily: "system-ui, sans-serif", color: "var(--color-text)" }}
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  Notifications
+                  {notifCount > 0 && (
+                    <span
+                      className="ml-2 badge text-white"
+                      style={{
+                        backgroundColor: "var(--color-error)",
+                        fontSize: "0.6rem",
+                      }}
+                    >
+                      {notifCount}
+                    </span>
+                  )}
+                </Link>
+                <button
+                  onClick={handleLogout}
+                  className="w-full text-left px-3 py-2.5 text-sm rounded-lg cursor-pointer"
+                  style={{
+                    fontFamily: "system-ui, sans-serif",
+                    color: "var(--color-error)",
+                    background: "none",
+                    border: "none",
+                  }}
+                >
+                  Sign out
+                </button>
+              </>
+            ) : (
+              <div className="flex gap-3 py-1">
+                <Link
+                  href="/auth/login"
+                  className="btn-secondary text-sm flex-1 text-center"
+                  style={{ padding: "0.5rem 1rem" }}
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  Sign in
+                </Link>
+                <Link
+                  href="/auth/register"
+                  className="btn-primary text-sm flex-1 text-center"
+                  style={{ padding: "0.5rem 1rem" }}
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  Sign up
+                </Link>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- Add mobile hamburger menu to Navbar (collapses at `sm` breakpoint)
- Add responsive typography, spacing, and layout to all pages
- Filter panel uses responsive CSS grid instead of fixed `minWidth`
- Listing detail stacks vertically on mobile, horizontal on desktop
- Profile tabs scroll horizontally on small screens
- Auth pages use reduced top margin on mobile

Fixes #52

## Changes
- `components/Navbar.tsx` — mobile hamburger menu with slide-down panel
- `app/layout.tsx` — responsive container padding
- `app/page.tsx` — responsive heading, filter grid layout
- `app/listings/[id]/ListingDetail.tsx` — responsive flex direction, book cover sizing
- `app/listings/create/page.tsx` — responsive heading/spacing
- `app/auth/login/page.tsx` + `register/page.tsx` — responsive top margin
- `app/profile/page.tsx` — responsive tabs, reputation layout
- `app/notifications/page.tsx` — responsive heading

## Test plan
- [ ] Verify desktop layout unchanged at 1280px+
- [ ] Verify mobile layout at 375px (iPhone SE) — no horizontal overflow
- [ ] Verify hamburger menu opens/closes on mobile
- [ ] Verify filter panel renders as stacked grid on mobile
- [ ] Verify listing detail stacks book cover above text on mobile
- [ ] Verify profile tabs are scrollable on narrow screens

![desktop](/.claude-beat/logs/screenshots/prod-desktop-20260321.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)