### PR TITLE
feat: next/image optimization + SEO (robots.txt & sitemap)

### DIFF
--- a/app/app/listings/[id]/ListingDetail.tsx
+++ b/app/app/listings/[id]/ListingDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
+import Image from "next/image";
 
 interface Member {
   id: number;
@@ -415,9 +416,11 @@ export default function ListingDetail() {
       <div className="card mb-6">
         <div className="flex flex-col sm:flex-row gap-4 sm:gap-5">
           {listing.book_cover_url ? (
-            <img
+            <Image
               src={listing.book_cover_url}
               alt={listing.book_title}
+              width={96}
+              height={144}
               className="w-20 h-28 sm:w-24 sm:h-36 object-cover rounded-lg shadow-sm"
               style={{ flexShrink: 0 }}
             />

--- a/app/app/listings/create/page.tsx
+++ b/app/app/listings/create/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import BookSearch from "@/components/BookSearch";
+import Image from "next/image";
 
 export default function CreateListingPage() {
   const router = useRouter();
@@ -119,9 +120,11 @@ export default function CreateListingPage() {
               style={{ backgroundColor: "rgba(224, 122, 58, 0.06)" }}
             >
               {bookCoverUrl && (
-                <img
+                <Image
                   src={bookCoverUrl}
                   alt={`Cover of ${bookTitle}`}
+                  width={40}
+                  height={56}
                   className="w-10 h-14 object-cover rounded"
                 />
               )}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
+import Image from "next/image";
 
 interface Listing {
   id: number;
@@ -485,9 +486,11 @@ export default function HomePage() {
                 className="card hover:shadow-md transition-shadow flex gap-4"
               >
                 {listing.book_cover_url ? (
-                  <img
+                  <Image
                     src={listing.book_cover_url}
                     alt={listing.book_title}
+                    width={64}
+                    height={96}
                     className="w-16 h-24 object-cover rounded"
                     style={{ flexShrink: 0 }}
                   />

--- a/app/app/profile/page.tsx
+++ b/app/app/profile/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 
 interface ReadingItem {
   id: number;
@@ -660,12 +661,12 @@ function ReadingSection({
             >
               {/* Book Cover */}
               {item.book_cover_url ? (
-                <img
+                <Image
                   src={item.book_cover_url}
                   alt={item.book_title}
+                  width={48}
+                  height={72}
                   style={{
-                    width: 48,
-                    height: 72,
                     objectFit: "cover",
                     borderRadius: 4,
                     flexShrink: 0,

--- a/app/app/robots.ts
+++ b/app/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://89.167.127.85:3000";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/auth/", "/profile", "/notifications"],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/app/app/sitemap.ts
+++ b/app/app/sitemap.ts
@@ -1,0 +1,49 @@
+import type { MetadataRoute } from "next";
+import db from "@/lib/db";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://89.167.127.85:3000";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/auth/login`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${BASE_URL}/auth/register`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${BASE_URL}/listings/create`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+  ];
+
+  // Add open listing pages
+  const listings = db
+    .prepare(
+      `SELECT id, created_at FROM listings WHERE is_full = 0 ORDER BY created_at DESC`
+    )
+    .all() as { id: number; created_at: string }[];
+
+  const listingPages: MetadataRoute.Sitemap = listings.map((listing) => ({
+    url: `${BASE_URL}/listings/${listing.id}`,
+    lastModified: new Date(listing.created_at),
+    changeFrequency: "daily" as const,
+    priority: 0.8,
+  }));
+
+  return [...staticPages, ...listingPages];
+}

--- a/app/components/BookSearch.tsx
+++ b/app/components/BookSearch.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import Image from "next/image";
 
 interface BookResult {
   key: string;
@@ -178,9 +179,11 @@ export default function BookSearch({ onSelect }: Props) {
               }}
             >
               {book.cover_i ? (
-                <img
+                <Image
                   src={`https://covers.openlibrary.org/b/id/${book.cover_i}-S.jpg`}
                   alt={`Cover of ${book.title}`}
+                  width={32}
+                  height={48}
                   className="w-8 h-12 object-cover rounded"
                 />
               ) : (


### PR DESCRIPTION
## Summary
- **Replace all `<img>` tags with `next/image` `<Image>`** across 5 components (homepage, book search, listing detail, create listing, profile) — enables automatic lazy loading, WebP/AVIF format negotiation, and responsive srcset generation
- **Add `robots.ts`** — blocks crawlers from `/api/`, `/auth/`, `/profile`, `/notifications` while allowing the rest
- **Add `sitemap.ts`** — dynamically generates sitemap with static pages + all open listings from the database

## Changes
| File | Change |
|------|--------|
| `app/page.tsx` | `<img>` → `<Image>` for listing covers |
| `components/BookSearch.tsx` | `<img>` → `<Image>` for search result thumbnails |
| `listings/[id]/ListingDetail.tsx` | `<img>` → `<Image>` for detail page cover |
| `listings/create/page.tsx` | `<img>` → `<Image>` for selected book preview |
| `profile/page.tsx` | `<img>` → `<Image>` for reading history covers |
| `app/robots.ts` | New — Next.js robots.txt route handler |
| `app/sitemap.ts` | New — Next.js dynamic sitemap generator |

## Test plan
- [ ] Verify book cover images load correctly on homepage
- [ ] Verify book search dropdown shows cover thumbnails
- [ ] Verify listing detail page shows book cover
- [ ] Verify create listing page shows selected book cover
- [ ] Verify profile page reading history shows covers
- [ ] Visit `/robots.txt` — should show disallow rules for API/auth
- [ ] Visit `/sitemap.xml` — should list all open listings

Closes #55, closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)