### PR TITLE
test: expand test coverage to 59 tests

### DIFF
--- a/app/__tests__/api/notifications/notifications.test.ts
+++ b/app/__tests__/api/notifications/notifications.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest } from "../../helpers/mock-request";
+
+const testDb = vi.hoisted(() => {
+  const Db = require("better-sqlite3");
+  const db = new Db(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      bio TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS listings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      book_title TEXT NOT NULL,
+      book_author TEXT NOT NULL,
+      book_cover_url TEXT DEFAULT '',
+      book_olid TEXT DEFAULT '',
+      language TEXT DEFAULT 'English',
+      reading_pace TEXT NOT NULL,
+      start_date TEXT NOT NULL,
+      meeting_format TEXT NOT NULL CHECK(meeting_format IN ('voice', 'text', 'mixed')),
+      max_group_size INTEGER NOT NULL CHECK(max_group_size >= 2 AND max_group_size <= 20),
+      telegram_link TEXT DEFAULT '',
+      is_full INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (author_id) REFERENCES users(id)
+    );
+    CREATE TABLE IF NOT EXISTS notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      listing_id INTEGER,
+      type TEXT NOT NULL,
+      message TEXT NOT NULL,
+      is_read INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users(id),
+      FOREIGN KEY (listing_id) REFERENCES listings(id)
+    );
+  `);
+  return db;
+});
+
+const mockRequireAuth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ default: testDb }));
+
+vi.mock("@/lib/session", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+const { GET, PATCH } = await import("@/app/api/notifications/route");
+
+describe("GET /api/notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testDb.exec("DELETE FROM notifications");
+    testDb.exec("DELETE FROM listings");
+    testDb.exec("DELETE FROM users");
+
+    testDb.prepare(
+      "INSERT INTO users (id, email, password_hash, display_name) VALUES (?, ?, ?, ?)"
+    ).run(1, "user@test.com", "hash", "Test User");
+
+    testDb.prepare(
+      "INSERT INTO listings (id, author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    ).run(1, 1, "Test Book", "Test Author", "1 chapter/week", "2026-04-01", "text", 4);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAuth.mockResolvedValue(null);
+    const response = await GET();
+    expect(response.status).toBe(401);
+  });
+
+  it("returns empty notifications for new user", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.notifications).toEqual([]);
+    expect(data.unreadCount).toBe(0);
+  });
+
+  it("returns notifications with unread count", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+
+    testDb.prepare(
+      "INSERT INTO notifications (user_id, listing_id, type, message, is_read) VALUES (?, ?, ?, ?, ?)"
+    ).run(1, 1, "member_joined", "Someone joined your group", 0);
+    testDb.prepare(
+      "INSERT INTO notifications (user_id, listing_id, type, message, is_read) VALUES (?, ?, ?, ?, ?)"
+    ).run(1, 1, "group_full", "Your group is now full", 1);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.notifications).toHaveLength(2);
+    expect(data.unreadCount).toBe(1);
+  });
+
+  it("includes book_title from listing join", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+
+    testDb.prepare(
+      "INSERT INTO notifications (user_id, listing_id, type, message) VALUES (?, ?, ?, ?)"
+    ).run(1, 1, "member_joined", "Someone joined");
+
+    const response = await GET();
+    const data = await response.json();
+    expect(data.notifications[0].book_title).toBe("Test Book");
+  });
+});
+
+describe("PATCH /api/notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testDb.exec("DELETE FROM notifications");
+    testDb.exec("DELETE FROM listings");
+    testDb.exec("DELETE FROM users");
+
+    testDb.prepare(
+      "INSERT INTO users (id, email, password_hash, display_name) VALUES (?, ?, ?, ?)"
+    ).run(1, "user@test.com", "hash", "Test User");
+
+    testDb.prepare(
+      "INSERT INTO listings (id, author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    ).run(1, 1, "Test Book", "Test Author", "1 chapter/week", "2026-04-01", "text", 4);
+
+    testDb.prepare(
+      "INSERT INTO notifications (id, user_id, listing_id, type, message, is_read) VALUES (?, ?, ?, ?, ?, ?)"
+    ).run(1, 1, 1, "member_joined", "Someone joined", 0);
+    testDb.prepare(
+      "INSERT INTO notifications (id, user_id, listing_id, type, message, is_read) VALUES (?, ?, ?, ?, ?, ?)"
+    ).run(2, 1, 1, "group_full", "Group is full", 0);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAuth.mockResolvedValue(null);
+    const req = createTestRequest("/api/notifications", {
+      method: "PATCH",
+      body: { notificationId: 1 },
+    });
+    const response = await PATCH(req);
+    expect(response.status).toBe(401);
+  });
+
+  it("marks a single notification as read", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+
+    const req = createTestRequest("/api/notifications", {
+      method: "PATCH",
+      body: { notificationId: 1 },
+    });
+    const response = await PATCH(req);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.ok).toBe(true);
+
+    // Verify only one was marked as read
+    const unread = testDb.prepare(
+      "SELECT COUNT(*) as count FROM notifications WHERE user_id = 1 AND is_read = 0"
+    ).get() as { count: number };
+    expect(unread.count).toBe(1);
+  });
+
+  it("marks all notifications as read when no notificationId", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+
+    const req = createTestRequest("/api/notifications", {
+      method: "PATCH",
+      body: {},
+    });
+    const response = await PATCH(req);
+    expect(response.status).toBe(200);
+
+    const unread = testDb.prepare(
+      "SELECT COUNT(*) as count FROM notifications WHERE user_id = 1 AND is_read = 0"
+    ).get() as { count: number };
+    expect(unread.count).toBe(0);
+  });
+});

--- a/app/__tests__/api/profile/profile.test.ts
+++ b/app/__tests__/api/profile/profile.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest } from "../../helpers/mock-request";
+
+const testDb = vi.hoisted(() => {
+  const Db = require("better-sqlite3");
+  const db = new Db(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      bio TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+  `);
+  return db;
+});
+
+const mockSession = vi.hoisted(() => ({
+  userId: 1 as number | undefined,
+  displayName: "Test User" as string | undefined,
+  save: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockRequireAuth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ default: testDb }));
+
+vi.mock("@/lib/session", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+const { PATCH } = await import("@/app/api/profile/route");
+
+describe("PATCH /api/profile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testDb.exec("DELETE FROM users");
+
+    testDb.prepare(
+      "INSERT INTO users (id, email, password_hash, display_name, bio) VALUES (?, ?, ?, ?, ?)"
+    ).run(1, "user@test.com", "hash", "Test User", "Old bio");
+
+    mockSession.userId = 1;
+    mockSession.displayName = "Test User";
+    mockSession.save.mockResolvedValue(undefined);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAuth.mockResolvedValue(null);
+    const req = createTestRequest("/api/profile", {
+      method: "PATCH",
+      body: { displayName: "New Name" },
+    });
+    const response = await PATCH(req);
+    expect(response.status).toBe(401);
+  });
+
+  it("updates display name and bio", async () => {
+    mockRequireAuth.mockResolvedValue(mockSession);
+
+    const req = createTestRequest("/api/profile", {
+      method: "PATCH",
+      body: { displayName: "New Name", bio: "New bio" },
+    });
+    const response = await PATCH(req);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.ok).toBe(true);
+
+    const user = testDb.prepare("SELECT display_name, bio FROM users WHERE id = 1").get() as { display_name: string; bio: string };
+    expect(user.display_name).toBe("New Name");
+    expect(user.bio).toBe("New bio");
+  });
+
+  it("returns 400 when display name is empty", async () => {
+    mockRequireAuth.mockResolvedValue(mockSession);
+
+    const req = createTestRequest("/api/profile", {
+      method: "PATCH",
+      body: { displayName: "", bio: "Some bio" },
+    });
+    const response = await PATCH(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when display name is too long", async () => {
+    mockRequireAuth.mockResolvedValue(mockSession);
+
+    const req = createTestRequest("/api/profile", {
+      method: "PATCH",
+      body: { displayName: "x".repeat(101), bio: "Some bio" },
+    });
+    const response = await PATCH(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when bio is too long", async () => {
+    mockRequireAuth.mockResolvedValue(mockSession);
+
+    const req = createTestRequest("/api/profile", {
+      method: "PATCH",
+      body: { displayName: "Valid Name", bio: "x".repeat(501) },
+    });
+    const response = await PATCH(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("trims whitespace from display name", async () => {
+    mockRequireAuth.mockResolvedValue(mockSession);
+
+    const req = createTestRequest("/api/profile", {
+      method: "PATCH",
+      body: { displayName: "  Trimmed Name  ", bio: "" },
+    });
+    const response = await PATCH(req);
+    expect(response.status).toBe(200);
+
+    const user = testDb.prepare("SELECT display_name FROM users WHERE id = 1").get() as { display_name: string };
+    expect(user.display_name).toBe("Trimmed Name");
+  });
+
+  it("updates session displayName after save", async () => {
+    mockRequireAuth.mockResolvedValue(mockSession);
+
+    const req = createTestRequest("/api/profile", {
+      method: "PATCH",
+      body: { displayName: "Updated Name", bio: "" },
+    });
+    await PATCH(req);
+    expect(mockSession.displayName).toBe("Updated Name");
+    expect(mockSession.save).toHaveBeenCalled();
+  });
+});

--- a/app/__tests__/api/ratings/ratings.test.ts
+++ b/app/__tests__/api/ratings/ratings.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest } from "../../helpers/mock-request";
+
+const testDb = vi.hoisted(() => {
+  const Db = require("better-sqlite3");
+  const db = new Db(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      bio TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS listings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      book_title TEXT NOT NULL,
+      book_author TEXT NOT NULL,
+      book_cover_url TEXT DEFAULT '',
+      book_olid TEXT DEFAULT '',
+      language TEXT DEFAULT 'English',
+      reading_pace TEXT NOT NULL,
+      start_date TEXT NOT NULL,
+      meeting_format TEXT NOT NULL CHECK(meeting_format IN ('voice', 'text', 'mixed')),
+      max_group_size INTEGER NOT NULL CHECK(max_group_size >= 2 AND max_group_size <= 20),
+      telegram_link TEXT DEFAULT '',
+      is_full INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (author_id) REFERENCES users(id)
+    );
+    CREATE TABLE IF NOT EXISTS listing_members (
+      listing_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      joined_at TEXT DEFAULT (datetime('now')),
+      PRIMARY KEY (listing_id, user_id),
+      FOREIGN KEY (listing_id) REFERENCES listings(id),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+    CREATE TABLE IF NOT EXISTS notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      listing_id INTEGER,
+      type TEXT NOT NULL,
+      message TEXT NOT NULL,
+      is_read INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users(id),
+      FOREIGN KEY (listing_id) REFERENCES listings(id)
+    );
+    CREATE TABLE IF NOT EXISTS ratings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      listing_id INTEGER NOT NULL,
+      rater_id INTEGER NOT NULL,
+      rated_user_id INTEGER NOT NULL,
+      score INTEGER NOT NULL CHECK(score >= 1 AND score <= 5),
+      comment TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now')),
+      UNIQUE(listing_id, rater_id, rated_user_id),
+      FOREIGN KEY (listing_id) REFERENCES listings(id),
+      FOREIGN KEY (rater_id) REFERENCES users(id),
+      FOREIGN KEY (rated_user_id) REFERENCES users(id)
+    );
+  `);
+  return db;
+});
+
+const mockRequireAuth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ default: testDb }));
+
+vi.mock("@/lib/session", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  createNotification: vi.fn(),
+}));
+
+const { POST, GET } = await import("@/app/api/ratings/route");
+
+function seedData() {
+  testDb.exec("DELETE FROM ratings");
+  testDb.exec("DELETE FROM listing_members");
+  testDb.exec("DELETE FROM notifications");
+  testDb.exec("DELETE FROM listings");
+  testDb.exec("DELETE FROM users");
+
+  // Create users
+  testDb.prepare(
+    "INSERT INTO users (id, email, password_hash, display_name) VALUES (?, ?, ?, ?)"
+  ).run(1, "alice@test.com", "hash", "Alice");
+  testDb.prepare(
+    "INSERT INTO users (id, email, password_hash, display_name) VALUES (?, ?, ?, ?)"
+  ).run(2, "bob@test.com", "hash", "Bob");
+  testDb.prepare(
+    "INSERT INTO users (id, email, password_hash, display_name) VALUES (?, ?, ?, ?)"
+  ).run(3, "charlie@test.com", "hash", "Charlie");
+
+  // Create a full listing
+  testDb.prepare(
+    "INSERT INTO listings (id, author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size, is_full) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+  ).run(1, 1, "Test Book", "Author", "1 ch/week", "2026-01-01", "text", 3, 1);
+
+  // Add members
+  testDb.prepare("INSERT INTO listing_members (listing_id, user_id) VALUES (?, ?)").run(1, 1);
+  testDb.prepare("INSERT INTO listing_members (listing_id, user_id) VALUES (?, ?)").run(1, 2);
+  testDb.prepare("INSERT INTO listing_members (listing_id, user_id) VALUES (?, ?)").run(1, 3);
+}
+
+describe("POST /api/ratings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seedData();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAuth.mockResolvedValue(null);
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 2, score: 5 },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1 },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for invalid score", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 2, score: 6 },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for non-integer score", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 2, score: 3.5 },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when rating yourself", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 1, score: 5 },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("cannot rate yourself");
+  });
+
+  it("returns 404 for non-existent listing", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 999, ratedUserId: 2, score: 4 },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 for non-full listing", async () => {
+    // Create an open listing
+    testDb.prepare(
+      "INSERT INTO listings (id, author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size, is_full) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ).run(2, 1, "Open Book", "Author", "1 ch/week", "2026-01-01", "text", 4, 0);
+    testDb.prepare("INSERT INTO listing_members (listing_id, user_id) VALUES (?, ?)").run(2, 1);
+    testDb.prepare("INSERT INTO listing_members (listing_id, user_id) VALUES (?, ?)").run(2, 2);
+
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 2, ratedUserId: 2, score: 4 },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("completed reading groups");
+  });
+
+  it("returns 403 when rater is not a member", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 99 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 2, score: 4 },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 when rated user is not a member", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 99, score: 4 },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("successfully creates a rating", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 2, score: 5, comment: "Great reader!" },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.ok).toBe(true);
+
+    const rating = testDb.prepare(
+      "SELECT * FROM ratings WHERE listing_id = 1 AND rater_id = 1 AND rated_user_id = 2"
+    ).get() as { score: number; comment: string };
+    expect(rating.score).toBe(5);
+    expect(rating.comment).toBe("Great reader!");
+  });
+
+  it("updates existing rating instead of creating duplicate", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+
+    // First rating
+    const req1 = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 2, score: 3 },
+    });
+    await POST(req1);
+
+    // Update rating
+    const req2 = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 2, score: 5, comment: "Updated" },
+    });
+    const response = await POST(req2);
+    expect(response.status).toBe(200);
+
+    const ratings = testDb.prepare(
+      "SELECT * FROM ratings WHERE listing_id = 1 AND rater_id = 1 AND rated_user_id = 2"
+    ).all() as { score: number; comment: string }[];
+    expect(ratings).toHaveLength(1);
+    expect(ratings[0].score).toBe(5);
+    expect(ratings[0].comment).toBe("Updated");
+  });
+
+  it("returns 400 for comment exceeding 1000 chars", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings", {
+      method: "POST",
+      body: { listingId: 1, ratedUserId: 2, score: 4, comment: "x".repeat(1001) },
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("GET /api/ratings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seedData();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAuth.mockResolvedValue(null);
+    const req = createTestRequest("/api/ratings?listingId=1");
+    const response = await GET(req);
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when listingId is missing", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings");
+    const response = await GET(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for invalid listingId", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings?listingId=abc");
+    const response = await GET(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 403 for non-members", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 99 });
+    const req = createTestRequest("/api/ratings?listingId=1");
+    const response = await GET(req);
+    expect(response.status).toBe(403);
+  });
+
+  it("returns given and received ratings", async () => {
+    // Alice rates Bob
+    testDb.prepare(
+      "INSERT INTO ratings (listing_id, rater_id, rated_user_id, score, comment) VALUES (?, ?, ?, ?, ?)"
+    ).run(1, 1, 2, 5, "Great!");
+    // Charlie rates Alice
+    testDb.prepare(
+      "INSERT INTO ratings (listing_id, rater_id, rated_user_id, score, comment) VALUES (?, ?, ?, ?, ?)"
+    ).run(1, 3, 1, 4, "Good reader");
+
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+    const req = createTestRequest("/api/ratings?listingId=1");
+    const response = await GET(req);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.givenRatings).toHaveLength(1);
+    expect(data.givenRatings[0].rated_user_id).toBe(2);
+    expect(data.givenRatings[0].display_name).toBe("Bob");
+
+    expect(data.receivedRatings).toHaveLength(1);
+    expect(data.receivedRatings[0].rater_id).toBe(3);
+    expect(data.receivedRatings[0].display_name).toBe("Charlie");
+  });
+});

--- a/app/app/api/profile/reading/route.ts
+++ b/app/app/api/profile/reading/route.ts
@@ -49,11 +49,6 @@ export async function GET() {
 
   const today = new Date().toISOString().split("T")[0];
 
-  // Currently reading: groups that are full (active) or start_date <= today
-  const currentlyReading = readings.filter(
-    (r) => r.is_full === 1 || r.start_date <= today
-  );
-
   // Reading history: completed groups (full + start_date in the past)
   // Upcoming: not yet started and not full
   const history = readings.filter(

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -29,6 +29,7 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/better-sqlite3": "^7.6.13",
         "@types/nodemailer": "^7.0.11",
+        "@vitest/coverage-v8": "^4.1.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "typescript-eslint": "^8.57.1",
@@ -285,6 +286,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2142,6 +2153,37 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
+      "integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.0",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.0",
+        "vitest": "4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
@@ -2327,6 +2369,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3177,6 +3238,13 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3318,6 +3386,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -3708,6 +3815,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge2": {

--- a/app/package.json
+++ b/app/package.json
@@ -32,6 +32,7 @@
     "@types/bcryptjs": "^2.4.6",
     "@types/better-sqlite3": "^7.6.13",
     "@types/nodemailer": "^7.0.11",
+    "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "typescript-eslint": "^8.57.1",


### PR DESCRIPTION
## Summary
- Added 31 new tests covering three previously untested API routes:
  - **Notifications API** (7 tests): GET/PATCH for fetching and marking notifications as read
  - **Profile API** (7 tests): PATCH for updating display name, bio, validation, trimming
  - **Ratings API** (17 tests): POST/GET for creating, updating, and querying ratings with full authorization checks
- Fixed unused variable ESLint warning in `profile/reading/route.ts`
- Added `@vitest/coverage-v8` for coverage reporting (~88% statement coverage)

## Test plan
- [x] All 59 tests pass locally (`npm test`)
- [x] ESLint clean (no warnings)
- [x] Build passes
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)