### PR TITLE
fix: generateMetadata crash, platform notifications, tab caching

### DIFF
--- a/app/app/listings/[id]/page.tsx
+++ b/app/app/listings/[id]/page.tsx
@@ -23,48 +23,52 @@ export async function generateMetadata({
     return { title: "Listing not found — Bookmate" };
   }
 
-  const listing = db
-    .prepare(
-      `SELECT l.book_title, l.book_author, l.book_cover_url, l.reading_pace,
-              l.max_group_size, u.display_name as author_name
-       FROM listings l
-       JOIN users u ON l.author_id = u.id
-       WHERE l.id = ?`
-    )
-    .get(listingId) as ListingRow | undefined;
+  try {
+    const listing = db
+      .prepare(
+        `SELECT l.book_title, l.book_author, l.book_cover_url, l.reading_pace,
+                l.max_group_size, u.display_name as author_name
+         FROM listings l
+         JOIN users u ON l.author_id = u.id
+         WHERE l.id = ?`
+      )
+      .get(listingId) as ListingRow | undefined;
 
-  if (!listing) {
-    return { title: "Listing not found — Bookmate" };
+    if (!listing) {
+      return { title: "Listing not found — Bookmate" };
+    }
+
+    const title = `${listing.book_title} by ${listing.book_author} — Bookmate`;
+    const description = `Join a reading group for "${listing.book_title}" by ${listing.book_author}. Pace: ${listing.reading_pace}. Up to ${listing.max_group_size} readers. Posted by ${listing.author_name}.`;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        type: "article",
+        ...(listing.book_cover_url
+          ? {
+              images: [
+                {
+                  url: listing.book_cover_url,
+                  alt: `Cover of ${listing.book_title}`,
+                },
+              ],
+            }
+          : {}),
+      },
+      twitter: {
+        card: listing.book_cover_url ? "summary_large_image" : "summary",
+        title,
+        description,
+        ...(listing.book_cover_url ? { images: [listing.book_cover_url] } : {}),
+      },
+    };
+  } catch {
+    return { title: "Listing — Bookmate" };
   }
-
-  const title = `${listing.book_title} by ${listing.book_author} — Bookmate`;
-  const description = `Join a reading group for "${listing.book_title}" by ${listing.book_author}. Pace: ${listing.reading_pace}. Up to ${listing.max_group_size} readers. Posted by ${listing.author_name}.`;
-
-  return {
-    title,
-    description,
-    openGraph: {
-      title,
-      description,
-      type: "article",
-      ...(listing.book_cover_url
-        ? {
-            images: [
-              {
-                url: listing.book_cover_url,
-                alt: `Cover of ${listing.book_title}`,
-              },
-            ],
-          }
-        : {}),
-    },
-    twitter: {
-      card: listing.book_cover_url ? "summary_large_image" : "summary",
-      title,
-      description,
-      ...(listing.book_cover_url ? { images: [listing.book_cover_url] } : {}),
-    },
-  };
 }
 
 export default function ListingPage() {

--- a/app/app/profile/page.tsx
+++ b/app/app/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
@@ -66,6 +66,9 @@ export default function ProfilePage() {
   const [reputation, setReputation] = useState<Reputation | null>(null);
   const [reputationLoading, setReputationLoading] = useState(false);
 
+  // Track which tabs have been fetched to avoid redundant requests
+  const fetchedTabs = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     fetch("/api/auth/me")
       .then((r) => r.json())
@@ -121,6 +124,8 @@ export default function ProfilePage() {
   }, []);
 
   useEffect(() => {
+    if (fetchedTabs.current.has(activeTab)) return;
+    fetchedTabs.current.add(activeTab);
     if (activeTab === "reading") fetchReading();
     if (activeTab === "genres") fetchGenres();
     if (activeTab === "reputation") fetchReputation();

--- a/app/lib/notifications.ts
+++ b/app/lib/notifications.ts
@@ -108,17 +108,20 @@ export function notifyApplicationDecision(
 
 export function notifyGroupFull(listingId: number) {
   const listing = db
-    .prepare("SELECT book_title FROM listings WHERE id = ?")
-    .get(listingId) as { book_title: string } | undefined;
+    .prepare("SELECT book_title, platform_preference FROM listings WHERE id = ?")
+    .get(listingId) as { book_title: string; platform_preference: string } | undefined;
   const members = db
     .prepare("SELECT user_id FROM listing_members WHERE listing_id = ?")
     .all(listingId) as { user_id: number }[];
 
   if (listing) {
-    const botConfigured = !!process.env.TELEGRAM_BOT_TOKEN;
+    const platform = listing.platform_preference === "discord" ? "Discord" : "Telegram";
+    const botConfigured = listing.platform_preference === "discord"
+      ? !!process.env.DISCORD_BOT_TOKEN
+      : !!process.env.TELEGRAM_BOT_TOKEN;
     const message = botConfigured
-      ? `The reading group for "${listing.book_title}" is now full! The Telegram group will be set up automatically.`
-      : `The reading group for "${listing.book_title}" is now full! The organizer will share a Telegram link soon.`;
+      ? `The reading group for "${listing.book_title}" is now full! The ${platform} group will be set up automatically.`
+      : `The reading group for "${listing.book_title}" is now full! The organizer will share a ${platform} link soon.`;
 
     for (const member of members) {
       createNotification(


### PR DESCRIPTION
## Summary
- **generateMetadata crash prevention**: Wrapped DB call in `listings/[id]/page.tsx` with try/catch so database errors return a fallback title instead of crashing the page with a 500
- **Platform-aware notifications**: `notifyGroupFull` now reads `platform_preference` from the listing and uses the correct platform name (Telegram/Discord) in notification messages — previously all groups said "Telegram"
- **Profile tab data caching**: Added a `fetchedTabs` ref to prevent redundant API requests when switching between profile tabs, eliminating unnecessary loading spinners

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 60 tests pass (`npm test`)
- [ ] CI validates on push

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)