### PR TITLE
feat: auto-hide listings with past start dates

### DIFF
--- a/app/app/api/listings/route.ts
+++ b/app/app/api/listings/route.ts
@@ -11,11 +11,18 @@ export async function GET(request: NextRequest) {
   const readingPace = searchParams.get("reading_pace") || "";
   const startDateFrom = searchParams.get("start_date_from") || "";
   const sort = searchParams.get("sort") || "newest";
+  const includePast = searchParams.get("include_past") === "true";
   const pageParam = parseInt(searchParams.get("page") || "1", 10);
   const page = isNaN(pageParam) || pageParam < 1 ? 1 : pageParam;
 
   const conditions: string[] = ["l.is_full = 0"];
   const params: (string | number)[] = [];
+
+  // By default, hide listings with start dates in the past
+  if (!includePast) {
+    conditions.push("l.start_date >= ?");
+    params.push(new Date().toISOString().split("T")[0]);
+  }
 
   if (q && q.length <= 300) {
     conditions.push("(l.book_title LIKE ? OR l.book_author LIKE ?)");

--- a/app/app/listings/[id]/ListingDetail.tsx
+++ b/app/app/listings/[id]/ListingDetail.tsx
@@ -470,19 +470,34 @@ export default function ListingDetail() {
               by {listing.book_author}
             </p>
 
-            {listing.requires_approval ? (
-              <span
-                className="badge mb-3"
-                style={{
-                  backgroundColor: "rgba(224, 122, 58, 0.1)",
-                  color: "var(--color-accent)",
-                  fontSize: "0.7rem",
-                  fontFamily: "system-ui, sans-serif",
-                }}
-              >
-                Approval required
-              </span>
-            ) : null}
+            <div className="flex flex-wrap gap-2 mb-3">
+              {new Date(listing.start_date) < new Date(new Date().toISOString().split("T")[0]) && (
+                <span
+                  className="badge"
+                  style={{
+                    backgroundColor: "rgba(107, 114, 128, 0.1)",
+                    color: "#6b7280",
+                    fontSize: "0.7rem",
+                    fontFamily: "system-ui, sans-serif",
+                  }}
+                >
+                  Past start date
+                </span>
+              )}
+              {listing.requires_approval ? (
+                <span
+                  className="badge"
+                  style={{
+                    backgroundColor: "rgba(224, 122, 58, 0.1)",
+                    color: "var(--color-accent)",
+                    fontSize: "0.7rem",
+                    fontFamily: "system-ui, sans-serif",
+                  }}
+                >
+                  Approval required
+                </span>
+              ) : null}
+            </div>
 
             <div
               className="grid grid-cols-2 gap-y-2 gap-x-4 sm:gap-x-6 text-sm"


### PR DESCRIPTION
## Summary
- Listings with start dates in the past are now hidden from the browse feed by default
- Added `?include_past=true` query parameter to the listings API for viewing past listings
- Added a "Past start date" badge on listing detail pages for listings with past start dates

Closes #66

## Test plan
- [x] All 60 existing tests pass
- [x] Build passes cleanly
- [x] Lint passes
- [ ] Browse feed no longer shows listings with past start dates
- [ ] Adding `?include_past=true` to API shows past listings
- [ ] Listing detail page shows "Past start date" badge for old listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)