### PR TITLE
fix: BookCover component with error fallback

### DIFF
--- a/app/app/listings/[id]/ListingDetail.tsx
+++ b/app/app/listings/[id]/ListingDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
-import Image from "next/image";
+import BookCover from "@/components/BookCover";
 
 interface Member {
   id: number;
@@ -437,26 +437,14 @@ export default function ListingDetail() {
 
       <div className="card mb-6">
         <div className="flex flex-col sm:flex-row gap-4 sm:gap-5">
-          {listing.book_cover_url ? (
-            <Image
-              src={listing.book_cover_url}
-              alt={listing.book_title}
-              width={96}
-              height={144}
-              className="w-20 h-28 sm:w-24 sm:h-36 object-cover rounded-lg shadow-sm"
-              style={{ flexShrink: 0 }}
-            />
-          ) : (
-            <div
-              className="w-20 h-28 sm:w-24 sm:h-36 rounded-lg flex items-center justify-center text-3xl sm:text-4xl"
-              style={{
-                backgroundColor: "var(--color-border)",
-                flexShrink: 0,
-              }}
-            >
-              📖
-            </div>
-          )}
+          <BookCover
+            src={listing.book_cover_url}
+            alt={listing.book_title}
+            width={96}
+            height={144}
+            className="w-20 h-28 sm:w-24 sm:h-36 object-cover rounded-lg shadow-sm"
+            style={{ flexShrink: 0 }}
+          />
 
           <div className="flex-1">
             <h1 className="text-xl sm:text-2xl mb-1">{listing.book_title}</h1>

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
-import Image from "next/image";
+import BookCover from "@/components/BookCover";
 
 interface Listing {
   id: number;
@@ -509,28 +509,14 @@ export default function HomePage() {
                 className="card hover:shadow-md transition-shadow flex gap-4"
                 role="listitem"
               >
-                {listing.book_cover_url ? (
-                  <Image
-                    src={listing.book_cover_url}
-                    alt={listing.book_title}
-                    width={64}
-                    height={96}
-                    className="w-16 h-24 object-cover rounded"
-                    style={{ flexShrink: 0 }}
-                  />
-                ) : (
-                  <div
-                    className="w-16 h-24 rounded flex items-center justify-center text-2xl"
-                    style={{
-                      backgroundColor: "var(--color-border)",
-                      flexShrink: 0,
-                      color: "var(--color-text-secondary)",
-                    }}
-                    aria-hidden="true"
-                  >
-                    📖
-                  </div>
-                )}
+                <BookCover
+                  src={listing.book_cover_url}
+                  alt={listing.book_title}
+                  width={64}
+                  height={96}
+                  className="w-16 h-24 object-cover rounded"
+                  style={{ flexShrink: 0 }}
+                />
 
                 <div className="flex-1 min-w-0">
                   <h3 className="text-lg font-bold truncate">

--- a/app/app/profile/page.tsx
+++ b/app/app/profile/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
+import BookCover from "@/components/BookCover";
 
 interface ReadingItem {
   id: number;
@@ -665,35 +665,14 @@ function ReadingSection({
               style={{ display: "flex", textDecoration: "none", color: "inherit" }}
             >
               {/* Book Cover */}
-              {item.book_cover_url ? (
-                <Image
-                  src={item.book_cover_url}
-                  alt={item.book_title}
-                  width={48}
-                  height={72}
-                  style={{
-                    objectFit: "cover",
-                    borderRadius: 4,
-                    flexShrink: 0,
-                  }}
-                />
-              ) : (
-                <div
-                  style={{
-                    width: 48,
-                    height: 72,
-                    backgroundColor: "var(--color-border)",
-                    borderRadius: 4,
-                    flexShrink: 0,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                  aria-hidden="true"
-                >
-                  <span style={{ fontSize: 20 }} aria-hidden="true">&#128214;</span>
-                </div>
-              )}
+              <BookCover
+                src={item.book_cover_url}
+                alt={item.book_title}
+                width={48}
+                height={72}
+                className="object-cover rounded"
+                style={{ flexShrink: 0 }}
+              />
 
               {/* Book Info */}
               <div style={{ flex: 1, minWidth: 0 }}>

--- a/app/components/BookCover.tsx
+++ b/app/components/BookCover.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+
+interface BookCoverProps {
+  src: string | null | undefined;
+  alt: string;
+  width: number;
+  height: number;
+  className?: string;
+  fallbackClassName?: string;
+  style?: React.CSSProperties;
+}
+
+export default function BookCover({
+  src,
+  alt,
+  width,
+  height,
+  className = "",
+  fallbackClassName = "",
+  style,
+}: BookCoverProps) {
+  const [hasError, setHasError] = useState(false);
+
+  if (!src || hasError) {
+    return (
+      <div
+        className={
+          fallbackClassName ||
+          `${className} flex items-center justify-center text-2xl`
+        }
+        style={{
+          width,
+          height,
+          backgroundColor: "var(--color-border)",
+          flexShrink: 0,
+          color: "var(--color-text-secondary)",
+          ...style,
+        }}
+        role="img"
+        aria-label={`Cover for ${alt}`}
+      >
+        📖
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      className={className}
+      style={style}
+      unoptimized
+      onError={() => setHasError(true)}
+    />
+  );
+}

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -9,6 +9,14 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "covers.openlibrary.org",
       },
+      {
+        protocol: "https",
+        hostname: "archive.org",
+      },
+      {
+        protocol: "https",
+        hostname: "*.us.archive.org",
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Created reusable `BookCover` component with `onError` fallback to placeholder when images fail to load
- Added `unoptimized` prop to bypass Next.js image proxy — Open Library covers redirect through `archive.org` which isn't in the allowed domains
- Added `archive.org` and `*.us.archive.org` to `next.config.ts` remote patterns as defense-in-depth
- Deduplicated cover rendering logic from homepage, listing detail, and profile pages (3 files → 1 component)

## Test plan
- [x] Lint passes (0 warnings)
- [x] 60 tests pass
- [x] Build succeeds
- [x] Deployed to production and verified
- [x] Dune listing cover loads correctly
- [x] Homepage covers render properly
- [x] Error fallback shows placeholder emoji when image fails

![Dune cover working](.claude-beat/logs/screenshots/cover-dune-20260323.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)