### PR TITLE
fix: navbar menu, validation gaps, telegram/discord guards

### DIFF
--- a/app/app/api/discord/webhook/route.ts
+++ b/app/app/api/discord/webhook/route.ts
@@ -75,6 +75,13 @@ async function handleLink(body: {
     return NextResponse.json({ error: "Listing not found" }, { status: 404 });
   }
 
+  if (!listing.is_full) {
+    return NextResponse.json(
+      { error: "Cannot link Discord until the group is full" },
+      { status: 400 }
+    );
+  }
+
   if (listing.discord_link) {
     return NextResponse.json(
       { error: "Discord link already set for this listing" },

--- a/app/app/api/listings/[id]/route.ts
+++ b/app/app/api/listings/[id]/route.ts
@@ -154,8 +154,14 @@ export async function PATCH(
       return NextResponse.json({ error: "Reading pace is required (max 200 characters)" }, { status: 400 });
     }
 
-    if (startDate !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
-      return NextResponse.json({ error: "Invalid start date format (expected YYYY-MM-DD)" }, { status: 400 });
+    if (startDate !== undefined) {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+        return NextResponse.json({ error: "Invalid start date format (expected YYYY-MM-DD)" }, { status: 400 });
+      }
+      const today = new Date().toISOString().split("T")[0];
+      if (startDate < today) {
+        return NextResponse.json({ error: "Start date cannot be in the past" }, { status: 400 });
+      }
     }
 
     if (meetingFormat !== undefined && !["voice", "text", "mixed"].includes(meetingFormat)) {
@@ -179,6 +185,10 @@ export async function PATCH(
           { status: 400 }
         );
       }
+    }
+
+    if (language !== undefined && (!language || typeof language !== "string" || language.length > 100)) {
+      return NextResponse.json({ error: "Language is required (max 100 characters)" }, { status: 400 });
     }
 
     if (platformPreference !== undefined && !["telegram", "discord"].includes(platformPreference)) {

--- a/app/app/api/listings/create/route.ts
+++ b/app/app/api/listings/create/route.ts
@@ -64,6 +64,14 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const today = new Date().toISOString().split("T")[0];
+    if (startDate < today) {
+      return NextResponse.json(
+        { error: "Start date cannot be in the past" },
+        { status: 400 }
+      );
+    }
+
     const size = parseInt(maxGroupSize, 10);
     if (isNaN(size) || size < 2 || size > 20) {
       return NextResponse.json(

--- a/app/app/api/profile/reading/route.ts
+++ b/app/app/api/profile/reading/route.ts
@@ -51,16 +51,14 @@ export async function GET() {
 
   // Reading history: completed groups (full + start_date in the past)
   // Upcoming: not yet started and not full
-  const history = readings.filter(
-    (r) => r.is_full === 1 && r.start_date < today
-  );
+  // Active: everything else that has started or is full (but not completed)
+  const isHistory = (r: ReadingRow) => r.is_full === 1 && r.start_date < today;
+  const isUpcoming = (r: ReadingRow) => r.is_full === 0 && r.start_date > today;
 
-  const upcoming = readings.filter(
-    (r) => r.is_full === 0 && r.start_date > today
-  );
-
+  const history = readings.filter(isHistory);
+  const upcoming = readings.filter(isUpcoming);
   const active = readings.filter(
-    (r) => !history.includes(r) && !upcoming.includes(r) && (r.is_full === 1 || r.start_date <= today)
+    (r) => !isHistory(r) && !isUpcoming(r) && (r.is_full === 1 || r.start_date <= today)
   );
 
   return NextResponse.json({

--- a/app/app/api/telegram/webhook/route.ts
+++ b/app/app/api/telegram/webhook/route.ts
@@ -250,15 +250,23 @@ async function handleMessage(message: TelegramMessage) {
 
     const listingId = parseInt(linkMatch[1], 10);
 
-    // Verify this user is the listing author
+    // Verify this user is the listing author and the listing is full
     const listing = db
-      .prepare("SELECT author_id FROM listings WHERE id = ?")
-      .get(listingId) as { author_id: number } | undefined;
+      .prepare("SELECT author_id, is_full FROM listings WHERE id = ?")
+      .get(listingId) as { author_id: number; is_full: number } | undefined;
 
     if (!listing || listing.author_id !== linkedUser.user_id) {
       await sendMessage(
         message.chat.id,
         "You can only link Telegram groups to your own Bookmate listings."
+      );
+      return;
+    }
+
+    if (!listing.is_full) {
+      await sendMessage(
+        message.chat.id,
+        "This listing's group is not full yet. You can link a Telegram group once the group reaches its maximum size."
       );
       return;
     }

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState, useRef } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 
 interface User {
   id: number;
@@ -16,6 +16,7 @@ export default function Navbar() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const router = useRouter();
+  const pathname = usePathname();
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -47,7 +48,7 @@ export default function Navbar() {
   useEffect(() => {
     setMobileMenuOpen(false);
     setMenuOpen(false);
-  }, []);
+  }, [pathname]);
 
   const handleLogout = async () => {
     await fetch("/api/auth/logout", { method: "POST" });


### PR DESCRIPTION
## Summary
Fixes 6 bugs found during code review (#73):

- **Navbar mobile menu doesn't close on route change** — `useEffect` had empty dependency array `[]` instead of `[pathname]`. Menu stayed open after navigation on mobile.
- **`language` field unvalidated in PATCH** — no length cap or type check; arbitrary strings could be written to DB. Added max 100 char validation.
- **Past start dates accepted** — create and edit routes accepted dates in the past, causing listings to be immediately hidden from browse feed. Added server-side `>= today` check.
- **Telegram `/link_ID` bypassed `is_full` guard** — author could link a Telegram group before the listing was full. Added `is_full` check.
- **Discord webhook no `is_full` check** — webhook could link Discord to an unfilled listing. Added guard.
- **Profile reading fragile reference equality** — `Array.includes` on object references is correct but fragile; replaced with predicate functions.

## Test plan
- [x] Build passes clean
- [x] All 82 tests pass (11 test files)
- [ ] Browser test: verify mobile navbar closes on navigation
- [ ] API test: verify past start dates rejected on create/edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)