### PR TITLE
fix: validation gaps, delete notification bug, secure cookie

### DIFF
--- a/app/app/api/auth/register/route.ts
+++ b/app/app/api/auth/register/route.ts
@@ -54,6 +54,13 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
+      return NextResponse.json(
+        { error: "Please provide a valid email address" },
+        { status: 400 }
+      );
+    }
+
     // Check if email is already taken
     const existing = db
       .prepare("SELECT id FROM users WHERE email = ?")

--- a/app/app/api/listings/[id]/discord/route.ts
+++ b/app/app/api/listings/[id]/discord/route.ts
@@ -36,6 +36,7 @@ export async function POST(
 
   if (
     !discordLink ||
+    discordLink.length > 512 ||
     !(
       discordLink.startsWith("https://discord.gg/") ||
       discordLink.startsWith("https://discord.com/invite/")
@@ -44,7 +45,7 @@ export async function POST(
     return NextResponse.json(
       {
         error:
-          "Please provide a valid Discord invite link (https://discord.gg/... or https://discord.com/invite/...)",
+          "Please provide a valid Discord invite link (https://discord.gg/... or https://discord.com/invite/..., max 512 characters)",
       },
       { status: 400 }
     );

--- a/app/app/api/listings/[id]/route.ts
+++ b/app/app/api/listings/[id]/route.ts
@@ -283,32 +283,30 @@ export async function DELETE(
       .prepare("SELECT user_id FROM listing_members WHERE listing_id = ? AND user_id != ?")
       .all(listingId, session.userId) as { user_id: number }[];
 
-    // Delete in a transaction
+    // Delete in a transaction (notifications sent after, so they aren't wiped)
     const deleteTransaction = db.transaction(() => {
-      // Notify members before deletion
-      for (const member of members) {
-        try {
-          createNotification(
-            member.user_id,
-            listingId,
-            "listing_deleted",
-            `The reading group for "${listing.book_title}" has been cancelled by the organizer.`
-          );
-        } catch {
-          // Notification failure should not block deletion
-        }
-      }
-
-      // Delete related records first
       db.prepare("DELETE FROM listing_applications WHERE listing_id = ?").run(listingId);
       db.prepare("DELETE FROM listing_members WHERE listing_id = ?").run(listingId);
       db.prepare("DELETE FROM notifications WHERE listing_id = ?").run(listingId);
       db.prepare("DELETE FROM ratings WHERE listing_id = ?").run(listingId);
-      // Delete the listing itself
       db.prepare("DELETE FROM listings WHERE id = ?").run(listingId);
     });
 
     deleteTransaction();
+
+    // Send deletion notifications after transaction (listing_id is NULL since listing is gone)
+    for (const member of members) {
+      try {
+        createNotification(
+          member.user_id,
+          null,
+          "listing_deleted",
+          `The reading group for "${listing.book_title}" has been cancelled by the organizer.`
+        );
+      } catch {
+        // Notification failure should not block response
+      }
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/app/api/listings/[id]/telegram/route.ts
+++ b/app/app/api/listings/[id]/telegram/route.ts
@@ -34,9 +34,9 @@ export async function POST(
 
   const { telegramLink } = await req.json();
 
-  if (!telegramLink || !telegramLink.startsWith("https://t.me/")) {
+  if (!telegramLink || !telegramLink.startsWith("https://t.me/") || telegramLink.length > 512) {
     return NextResponse.json(
-      { error: "Please provide a valid Telegram invite link (https://t.me/...)" },
+      { error: "Please provide a valid Telegram invite link (https://t.me/..., max 512 characters)" },
       { status: 400 }
     );
   }

--- a/app/app/api/listings/route.ts
+++ b/app/app/api/listings/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
   const sort = searchParams.get("sort") || "newest";
   const includePast = searchParams.get("include_past") === "true";
   const pageParam = parseInt(searchParams.get("page") || "1", 10);
-  const page = isNaN(pageParam) || pageParam < 1 ? 1 : pageParam;
+  const page = isNaN(pageParam) || pageParam < 1 ? 1 : Math.min(pageParam, 1000);
 
   const conditions: string[] = ["l.is_full = 0"];
   const params: (string | number)[] = [];

--- a/app/app/api/ratings/route.ts
+++ b/app/app/api/ratings/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
   const body = await req.json();
   const { listingId, ratedUserId, score, comment } = body;
 
-  if (!listingId || !ratedUserId || !score) {
+  if (listingId == null || ratedUserId == null || score == null) {
     return NextResponse.json(
       { error: "listingId, ratedUserId, and score are required" },
       { status: 400 }

--- a/app/lib/notifications.ts
+++ b/app/lib/notifications.ts
@@ -10,7 +10,7 @@ function getUserEmail(userId: number): string | null {
 
 export function createNotification(
   userId: number,
-  listingId: number,
+  listingId: number | null,
   type: string,
   message: string
 ) {

--- a/app/lib/session.ts
+++ b/app/lib/session.ts
@@ -22,7 +22,7 @@ function getSessionOptions(): SessionOptions {
     cookieName: "bookmate_session",
     cookieOptions: {
       httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
+      secure: process.env.NODE_ENV === "production" && process.env.HTTPS_ENABLED === "true",
       sameSite: "lax",
       maxAge: 60 * 60 * 24 * 7, // 1 week
     },


### PR DESCRIPTION
## Summary
- Fix falsy check on `score=0` in ratings API (use `== null` instead of `!`)
- Add 512-char length cap on telegram and discord invite links to prevent DB inflation
- Add email format validation (`user@domain.tld`) in registration endpoint
- Fix delete transaction immediately wiping its own notifications — move `createNotification` calls after the transaction completes
- Fix `secure` cookie flag incompatible with HTTP-only production (now requires `HTTPS_ENABLED=true` env var)
- Cap page number at 1000 to prevent expensive SQLite OFFSET scans

Closes #76

## Test plan
- [x] All 82 tests pass
- [x] Build succeeds
- [x] Lint clean
- [ ] Verify registration rejects invalid emails (e.g., `notanemail`)
- [ ] Verify score=0 gets proper error message
- [ ] Verify link length > 512 is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)