### PR TITLE
fix: code review round 5 — notifications, platform links, validation

### DIFF
--- a/app/app/api/listings/[id]/applications/route.ts
+++ b/app/app/api/listings/[id]/applications/route.ts
@@ -33,7 +33,7 @@ export async function PATCH(
   const body = await req.json();
   const { applicationId, action } = body;
 
-  if (!applicationId || !["approve", "reject"].includes(action)) {
+  if (!applicationId || typeof applicationId !== "number" || !Number.isInteger(applicationId) || applicationId < 1 || !["approve", "reject"].includes(action)) {
     return NextResponse.json(
       { error: "Invalid request. Provide applicationId and action (approve/reject)." },
       { status: 400 }

--- a/app/app/api/listings/[id]/discord/route.ts
+++ b/app/app/api/listings/[id]/discord/route.ts
@@ -32,6 +32,13 @@ export async function POST(
     );
   }
 
+  if (!listing.is_full) {
+    return NextResponse.json(
+      { error: "Group must be full before sharing a platform link" },
+      { status: 400 }
+    );
+  }
+
   const { discordLink } = await req.json();
 
   if (

--- a/app/app/api/listings/[id]/telegram/route.ts
+++ b/app/app/api/listings/[id]/telegram/route.ts
@@ -32,6 +32,13 @@ export async function POST(
     );
   }
 
+  if (!listing.is_full) {
+    return NextResponse.json(
+      { error: "Group must be full before sharing a platform link" },
+      { status: 400 }
+    );
+  }
+
   const { telegramLink } = await req.json();
 
   if (!telegramLink || !telegramLink.startsWith("https://t.me/") || telegramLink.length > 512) {

--- a/app/app/listings/[id]/ListingDetail.tsx
+++ b/app/app/listings/[id]/ListingDetail.tsx
@@ -83,7 +83,7 @@ export default function ListingDetail() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
-  const fetchListing = async () => {
+  const fetchListing = useCallback(async () => {
     try {
       const res = await fetch(`/api/listings/${id}`);
       const data = await res.json();
@@ -101,12 +101,11 @@ export default function ListingDetail() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [id]);
 
   useEffect(() => {
     fetchListing();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
+  }, [fetchListing]);
 
   const handleDelete = async () => {
     setDeleting(true);

--- a/app/lib/notifications.ts
+++ b/app/lib/notifications.ts
@@ -112,11 +112,12 @@ export function notifyApplicationDecision(
 
 export function notifyGroupFull(listingId: number) {
   const listing = db
-    .prepare("SELECT book_title, platform_preference FROM listings WHERE id = ?")
-    .get(listingId) as { book_title: string; platform_preference: string } | undefined;
+    .prepare("SELECT book_title, platform_preference, author_id FROM listings WHERE id = ?")
+    .get(listingId) as { book_title: string; platform_preference: string; author_id: number } | undefined;
+  // Exclude the author — they already received a separate "new_member" notification
   const members = db
-    .prepare("SELECT user_id FROM listing_members WHERE listing_id = ?")
-    .all(listingId) as { user_id: number }[];
+    .prepare("SELECT user_id FROM listing_members WHERE listing_id = ? AND user_id != ?")
+    .all(listingId, listing?.author_id ?? -1) as { user_id: number }[];
 
   if (listing) {
     const platform = listing.platform_preference === "discord" ? "Discord" : "Telegram";


### PR DESCRIPTION
## Summary
- **Exclude author from group_full notifications** — Author was receiving both `new_member` and `group_full` notifications for the same join event because `notifyGroupFull` iterated all `listing_members` which always includes the author
- **Require `is_full` before setting platform links** — Telegram and Discord link-setting API routes now reject requests if the group isn't full yet, enforcing the intended flow
- **Validate `applicationId` as positive integer** — Non-numeric values now return 400 instead of silently producing a confusing 404
- **Wrap `fetchListing` in `useCallback`** — Removed ESLint suppression comment, proper dependency tracking

Closes #82

## Test plan
- [x] 128 existing tests pass
- [x] ESLint clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)