### PR TITLE
Test coverage for Telegram and Discord API routes

### DIFF
--- a/app/__tests__/api/discord/discord-setup.test.ts
+++ b/app/__tests__/api/discord/discord-setup.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest, parseResponse } from "../../helpers/mock-request";
+
+const mockDiscord = vi.hoisted(() => ({
+  isBotConfigured: vi.fn().mockReturnValue(true),
+  getBotInfo: vi.fn().mockResolvedValue({ id: "123456", username: "BookmateBot" }),
+}));
+
+vi.mock("@/lib/discord", () => mockDiscord);
+
+const { POST } = await import("@/app/api/discord/setup/route");
+
+describe("POST /api/discord/setup", () => {
+  beforeEach(() => {
+    vi.stubEnv("DISCORD_SETUP_SECRET", "discord-secret");
+    mockDiscord.isBotConfigured.mockReturnValue(true);
+    mockDiscord.getBotInfo.mockResolvedValue({ id: "123456", username: "BookmateBot" });
+  });
+
+  it("returns 403 when secret is wrong", async () => {
+    const req = createTestRequest("http://localhost:3000/api/discord/setup", {
+      method: "POST",
+      body: { secret: "wrong" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(403);
+  });
+
+  it("returns 403 when DISCORD_SETUP_SECRET is not configured", async () => {
+    vi.stubEnv("DISCORD_SETUP_SECRET", "");
+    const req = createTestRequest("http://localhost:3000/api/discord/setup", {
+      method: "POST",
+      body: { secret: "" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(403);
+  });
+
+  it("returns 503 when bot is not configured", async () => {
+    mockDiscord.isBotConfigured.mockReturnValue(false);
+    const req = createTestRequest("http://localhost:3000/api/discord/setup", {
+      method: "POST",
+      body: { secret: "discord-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(503);
+  });
+
+  it("returns 500 when getBotInfo fails", async () => {
+    mockDiscord.getBotInfo.mockResolvedValue(null);
+    const req = createTestRequest("http://localhost:3000/api/discord/setup", {
+      method: "POST",
+      body: { secret: "discord-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+
+  it("returns bot info on success", async () => {
+    const req = createTestRequest("http://localhost:3000/api/discord/setup", {
+      method: "POST",
+      body: { secret: "discord-secret" },
+    });
+    const res = await POST(req);
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      ok: true,
+      bot: { id: "123456", username: "BookmateBot" },
+      message: expect.stringContaining("BookmateBot"),
+    });
+  });
+});

--- a/app/__tests__/api/discord/discord-webhook.test.ts
+++ b/app/__tests__/api/discord/discord-webhook.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest, parseResponse } from "../../helpers/mock-request";
+
+const testDb = vi.hoisted(() => {
+  const Db = require("better-sqlite3");
+  const db = new Db(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      bio TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS listings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      book_title TEXT NOT NULL,
+      book_author TEXT NOT NULL,
+      book_cover_url TEXT DEFAULT '',
+      book_olid TEXT DEFAULT '',
+      language TEXT DEFAULT 'English',
+      reading_pace TEXT NOT NULL,
+      start_date TEXT NOT NULL,
+      meeting_format TEXT NOT NULL CHECK(meeting_format IN ('voice', 'text', 'mixed')),
+      max_group_size INTEGER NOT NULL CHECK(max_group_size >= 2 AND max_group_size <= 20),
+      telegram_link TEXT DEFAULT '',
+      is_full INTEGER DEFAULT 0,
+      requires_approval INTEGER DEFAULT 0,
+      platform_preference TEXT DEFAULT 'telegram',
+      discord_link TEXT DEFAULT '',
+      discord_channel_id TEXT DEFAULT '',
+      telegram_chat_id INTEGER,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (author_id) REFERENCES users(id)
+    );
+    CREATE TABLE IF NOT EXISTS listing_members (
+      listing_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      joined_at TEXT DEFAULT (datetime('now')),
+      PRIMARY KEY (listing_id, user_id),
+      FOREIGN KEY (listing_id) REFERENCES listings(id),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+    CREATE TABLE IF NOT EXISTS notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      listing_id INTEGER,
+      type TEXT NOT NULL,
+      message TEXT NOT NULL,
+      is_read INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+  `);
+  return db;
+});
+
+const mockDiscord = vi.hoisted(() => ({
+  createTextChannel: vi.fn().mockResolvedValue({ id: "ch-123", name: "bookmate-test-book" }),
+  createChannelInvite: vi.fn().mockResolvedValue("https://discord.gg/abc123"),
+  sendChannelMessage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/lib/db", () => ({ default: testDb }));
+
+vi.mock("@/lib/discord", () => mockDiscord);
+
+vi.mock("@/lib/notifications", () => ({
+  createNotification: vi.fn(),
+}));
+
+const { POST } = await import("@/app/api/discord/webhook/route");
+
+function insertUser(email = "test@example.com", name = "Test User") {
+  testDb
+    .prepare("INSERT INTO users (email, password_hash, display_name) VALUES (?, ?, ?)")
+    .run(email, "hash", name);
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+function insertListing(
+  authorId: number,
+  overrides: Partial<{
+    is_full: number;
+    discord_link: string;
+    book_title: string;
+  }> = {}
+) {
+  testDb
+    .prepare(
+      `INSERT INTO listings (author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size, is_full, discord_link)
+       VALUES (?, ?, 'Test Author', '1ch/wk', '2026-04-01', 'text', 5, ?, ?)`
+    )
+    .run(authorId, overrides.book_title ?? "Test Book", overrides.is_full ?? 0, overrides.discord_link ?? "");
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+function addMember(listingId: number, userId: number) {
+  testDb.prepare("INSERT INTO listing_members (listing_id, user_id) VALUES (?, ?)").run(listingId, userId);
+}
+
+describe("POST /api/discord/webhook", () => {
+  beforeEach(() => {
+    testDb.exec("DELETE FROM listing_members");
+    testDb.exec("DELETE FROM notifications");
+    testDb.exec("DELETE FROM listings");
+    testDb.exec("DELETE FROM users");
+    vi.stubEnv("DISCORD_WEBHOOK_SECRET", "discord-webhook-secret");
+    mockDiscord.createTextChannel.mockResolvedValue({ id: "ch-123", name: "bookmate-test-book" });
+    mockDiscord.createChannelInvite.mockResolvedValue("https://discord.gg/abc123");
+    mockDiscord.sendChannelMessage.mockResolvedValue(true);
+  });
+
+  it("returns 500 when webhook secret is not configured", async () => {
+    vi.stubEnv("DISCORD_WEBHOOK_SECRET", "");
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "g1", listingId: 1 },
+      headers: { "X-Discord-Webhook-Secret": "anything" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+
+  it("returns 403 when secret header is wrong", async () => {
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "g1", listingId: 1 },
+      headers: { "X-Discord-Webhook-Secret": "wrong" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(403);
+  });
+
+  it("returns 400 for unknown event type", async () => {
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "unknown" },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("responds to Discord PING with PONG", async () => {
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: 1 },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toEqual({ type: 1 });
+  });
+
+  it("returns 400 when guildId or listingId missing for link type", async () => {
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "", listingId: 0 },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 404 when listing not found", async () => {
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "guild-1", listingId: 999 },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(404);
+  });
+
+  it("returns 400 when group is not full", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 0 });
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "guild-1", listingId },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 400 when discord link already set", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1, discord_link: "https://discord.gg/existing" });
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "guild-1", listingId },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("creates channel and links successfully", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    addMember(listingId, userId);
+
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "guild-1", listingId },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toHaveProperty("ok", true);
+    expect(data).toHaveProperty("inviteLink", "https://discord.gg/abc123");
+
+    // Verify DB was updated
+    const listing = testDb.prepare("SELECT discord_link, discord_channel_id FROM listings WHERE id = ?").get(listingId) as {
+      discord_link: string;
+      discord_channel_id: string;
+    };
+    expect(listing.discord_link).toBe("https://discord.gg/abc123");
+    expect(listing.discord_channel_id).toBe("ch-123");
+  });
+
+  it("uses provided channelId instead of creating one", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    addMember(listingId, userId);
+
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "guild-1", listingId, channelId: "existing-ch" },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+
+    // Should not have created a new channel
+    expect(mockDiscord.createTextChannel).not.toHaveBeenCalled();
+
+    // Should have created invite for the existing channel
+    expect(mockDiscord.createChannelInvite).toHaveBeenCalledWith("existing-ch");
+  });
+
+  it("returns 500 when channel creation fails", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockDiscord.createTextChannel.mockResolvedValue(null);
+
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "guild-1", listingId },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+
+  it("returns 500 when invite creation fails", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockDiscord.createChannelInvite.mockResolvedValue(null);
+
+    const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
+      method: "POST",
+      body: { type: "link", guildId: "guild-1", listingId },
+      headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+});

--- a/app/__tests__/api/listings/listing-auto-discord.test.ts
+++ b/app/__tests__/api/listings/listing-auto-discord.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest, parseResponse } from "../../helpers/mock-request";
+
+const testDb = vi.hoisted(() => {
+  const Db = require("better-sqlite3");
+  const db = new Db(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      bio TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS listings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      book_title TEXT NOT NULL,
+      book_author TEXT NOT NULL,
+      book_cover_url TEXT DEFAULT '',
+      book_olid TEXT DEFAULT '',
+      language TEXT DEFAULT 'English',
+      reading_pace TEXT NOT NULL,
+      start_date TEXT NOT NULL,
+      meeting_format TEXT NOT NULL CHECK(meeting_format IN ('voice', 'text', 'mixed')),
+      max_group_size INTEGER NOT NULL CHECK(max_group_size >= 2 AND max_group_size <= 20),
+      telegram_link TEXT DEFAULT '',
+      is_full INTEGER DEFAULT 0,
+      requires_approval INTEGER DEFAULT 0,
+      platform_preference TEXT DEFAULT 'telegram',
+      discord_link TEXT DEFAULT '',
+      discord_channel_id TEXT DEFAULT '',
+      telegram_chat_id INTEGER,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (author_id) REFERENCES users(id)
+    );
+  `);
+  return db;
+});
+
+const mockSession = vi.hoisted(() => ({
+  userId: undefined as number | undefined,
+  email: undefined as string | undefined,
+  displayName: undefined as string | undefined,
+  save: vi.fn(),
+  destroy: vi.fn(),
+}));
+
+const mockDiscord = vi.hoisted(() => ({
+  isBotConfigured: vi.fn().mockReturnValue(true),
+  generateBotInviteUrl: vi.fn().mockReturnValue("https://discord.com/oauth2/authorize?client_id=123&permissions=3089&scope=bot&state=listing_1"),
+}));
+
+vi.mock("@/lib/db", () => ({ default: testDb }));
+
+vi.mock("@/lib/session", () => ({
+  getSession: vi.fn().mockResolvedValue(mockSession),
+  requireAuth: vi.fn().mockImplementation(async () => {
+    if (!mockSession.userId) return null;
+    return mockSession;
+  }),
+}));
+
+vi.mock("@/lib/discord", () => mockDiscord);
+
+const { GET } = await import("@/app/api/listings/[id]/auto-discord/route");
+
+function insertUser(email = "test@example.com", name = "Test User") {
+  testDb
+    .prepare("INSERT INTO users (email, password_hash, display_name) VALUES (?, ?, ?)")
+    .run(email, "hash", name);
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+function insertListing(
+  authorId: number,
+  overrides: Partial<{
+    is_full: number;
+    discord_link: string;
+  }> = {}
+) {
+  testDb
+    .prepare(
+      `INSERT INTO listings (author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size, is_full, discord_link)
+       VALUES (?, 'Test Book', 'Test Author', '1ch/wk', '2026-04-01', 'text', 5, ?, ?)`
+    )
+    .run(authorId, overrides.is_full ?? 0, overrides.discord_link ?? "");
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+describe("GET /api/listings/[id]/auto-discord", () => {
+  beforeEach(() => {
+    testDb.exec("DELETE FROM listings");
+    testDb.exec("DELETE FROM users");
+    mockSession.userId = undefined;
+    mockDiscord.isBotConfigured.mockReturnValue(true);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockSession.userId = undefined;
+    const req = createTestRequest("http://localhost:3000/api/listings/1/auto-discord");
+    const res = await GET(req, { params: Promise.resolve({ id: "1" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(401);
+  });
+
+  it("returns 503 when bot is not configured", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    mockDiscord.isBotConfigured.mockReturnValue(false);
+    const req = createTestRequest("http://localhost:3000/api/listings/1/auto-discord");
+    const res = await GET(req, { params: Promise.resolve({ id: "1" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(503);
+  });
+
+  it("returns 400 for invalid listing ID", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    const req = createTestRequest("http://localhost:3000/api/listings/abc/auto-discord");
+    const res = await GET(req, { params: Promise.resolve({ id: "abc" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 404 when listing not found", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    const req = createTestRequest("http://localhost:3000/api/listings/999/auto-discord");
+    const res = await GET(req, { params: Promise.resolve({ id: "999" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(404);
+  });
+
+  it("returns 403 when user is not the author", async () => {
+    const authorId = insertUser("author@test.com", "Author");
+    const otherId = insertUser("other@test.com", "Other");
+    const listingId = insertListing(authorId, { is_full: 1 });
+    mockSession.userId = otherId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/auto-discord`);
+    const res = await GET(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(403);
+  });
+
+  it("returns 400 when group is not full", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 0 });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/auto-discord`);
+    const res = await GET(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 400 when discord link already set", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1, discord_link: "https://discord.gg/existing" });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/auto-discord`);
+    const res = await GET(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns invite URL and instructions on success", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/auto-discord`);
+    const res = await GET(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toHaveProperty("inviteUrl");
+    expect(data).toHaveProperty("instructions");
+  });
+});

--- a/app/__tests__/api/listings/listing-auto-telegram.test.ts
+++ b/app/__tests__/api/listings/listing-auto-telegram.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest, parseResponse } from "../../helpers/mock-request";
+
+const testDb = vi.hoisted(() => {
+  const Db = require("better-sqlite3");
+  const db = new Db(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      bio TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS listings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      book_title TEXT NOT NULL,
+      book_author TEXT NOT NULL,
+      book_cover_url TEXT DEFAULT '',
+      book_olid TEXT DEFAULT '',
+      language TEXT DEFAULT 'English',
+      reading_pace TEXT NOT NULL,
+      start_date TEXT NOT NULL,
+      meeting_format TEXT NOT NULL CHECK(meeting_format IN ('voice', 'text', 'mixed')),
+      max_group_size INTEGER NOT NULL CHECK(max_group_size >= 2 AND max_group_size <= 20),
+      telegram_link TEXT DEFAULT '',
+      is_full INTEGER DEFAULT 0,
+      requires_approval INTEGER DEFAULT 0,
+      platform_preference TEXT DEFAULT 'telegram',
+      discord_link TEXT DEFAULT '',
+      discord_channel_id TEXT DEFAULT '',
+      telegram_chat_id INTEGER,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (author_id) REFERENCES users(id)
+    );
+  `);
+  return db;
+});
+
+const mockSession = vi.hoisted(() => ({
+  userId: undefined as number | undefined,
+  email: undefined as string | undefined,
+  displayName: undefined as string | undefined,
+  save: vi.fn(),
+  destroy: vi.fn(),
+}));
+
+const mockTelegram = vi.hoisted(() => ({
+  isBotConfigured: vi.fn().mockReturnValue(true),
+  generateGroupDeepLink: vi.fn().mockResolvedValue("https://t.me/BookmateBot?startgroup=listing_1"),
+}));
+
+vi.mock("@/lib/db", () => ({ default: testDb }));
+
+vi.mock("@/lib/session", () => ({
+  getSession: vi.fn().mockResolvedValue(mockSession),
+  requireAuth: vi.fn().mockImplementation(async () => {
+    if (!mockSession.userId) return null;
+    return mockSession;
+  }),
+}));
+
+vi.mock("@/lib/telegram", () => mockTelegram);
+
+const { GET } = await import("@/app/api/listings/[id]/auto-telegram/route");
+
+function insertUser(email = "test@example.com", name = "Test User") {
+  testDb
+    .prepare("INSERT INTO users (email, password_hash, display_name) VALUES (?, ?, ?)")
+    .run(email, "hash", name);
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+function insertListing(
+  authorId: number,
+  overrides: Partial<{
+    is_full: number;
+    telegram_link: string;
+  }> = {}
+) {
+  testDb
+    .prepare(
+      `INSERT INTO listings (author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size, is_full, telegram_link)
+       VALUES (?, 'Test Book', 'Test Author', '1ch/wk', '2026-04-01', 'text', 5, ?, ?)`
+    )
+    .run(authorId, overrides.is_full ?? 0, overrides.telegram_link ?? "");
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+describe("GET /api/listings/[id]/auto-telegram", () => {
+  beforeEach(() => {
+    testDb.exec("DELETE FROM listings");
+    testDb.exec("DELETE FROM users");
+    mockSession.userId = undefined;
+    mockTelegram.isBotConfigured.mockReturnValue(true);
+    mockTelegram.generateGroupDeepLink.mockResolvedValue("https://t.me/BookmateBot?startgroup=listing_1");
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const req = createTestRequest("http://localhost:3000/api/listings/1/auto-telegram");
+    const res = await GET(req, { params: Promise.resolve({ id: "1" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(401);
+  });
+
+  it("returns 404 when bot is not configured", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    mockTelegram.isBotConfigured.mockReturnValue(false);
+    const req = createTestRequest("http://localhost:3000/api/listings/1/auto-telegram");
+    const res = await GET(req, { params: Promise.resolve({ id: "1" }) });
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(404);
+    expect(data).toHaveProperty("botConfigured", false);
+  });
+
+  it("returns 400 for invalid listing ID", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    const req = createTestRequest("http://localhost:3000/api/listings/abc/auto-telegram");
+    const res = await GET(req, { params: Promise.resolve({ id: "abc" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 404 when listing not found", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    const req = createTestRequest("http://localhost:3000/api/listings/999/auto-telegram");
+    const res = await GET(req, { params: Promise.resolve({ id: "999" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(404);
+  });
+
+  it("returns 403 when user is not the author", async () => {
+    const authorId = insertUser("author@test.com", "Author");
+    const otherId = insertUser("other@test.com", "Other");
+    const listingId = insertListing(authorId, { is_full: 1 });
+    mockSession.userId = otherId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/auto-telegram`);
+    const res = await GET(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(403);
+  });
+
+  it("returns 400 when group is not full", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 0 });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/auto-telegram`);
+    const res = await GET(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 400 when telegram link already set", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1, telegram_link: "https://t.me/existing" });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/auto-telegram`);
+    const res = await GET(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(data).toHaveProperty("telegramLink", "https://t.me/existing");
+  });
+
+  it("returns deep link on success", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockSession.userId = userId;
+    mockTelegram.generateGroupDeepLink.mockResolvedValue(`https://t.me/BookmateBot?startgroup=listing_${listingId}`);
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/auto-telegram`);
+    const res = await GET(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toHaveProperty("deepLink");
+    expect(data).toHaveProperty("instructions");
+  });
+
+  it("returns 500 when deep link generation fails", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockSession.userId = userId;
+    mockTelegram.generateGroupDeepLink.mockResolvedValue(null);
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/auto-telegram`);
+    const res = await GET(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+});

--- a/app/__tests__/api/listings/listing-discord.test.ts
+++ b/app/__tests__/api/listings/listing-discord.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest, parseResponse } from "../../helpers/mock-request";
+
+const testDb = vi.hoisted(() => {
+  const Db = require("better-sqlite3");
+  const db = new Db(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      bio TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS listings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      book_title TEXT NOT NULL,
+      book_author TEXT NOT NULL,
+      book_cover_url TEXT DEFAULT '',
+      book_olid TEXT DEFAULT '',
+      language TEXT DEFAULT 'English',
+      reading_pace TEXT NOT NULL,
+      start_date TEXT NOT NULL,
+      meeting_format TEXT NOT NULL CHECK(meeting_format IN ('voice', 'text', 'mixed')),
+      max_group_size INTEGER NOT NULL CHECK(max_group_size >= 2 AND max_group_size <= 20),
+      telegram_link TEXT DEFAULT '',
+      is_full INTEGER DEFAULT 0,
+      requires_approval INTEGER DEFAULT 0,
+      platform_preference TEXT DEFAULT 'telegram',
+      discord_link TEXT DEFAULT '',
+      discord_channel_id TEXT DEFAULT '',
+      telegram_chat_id INTEGER,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (author_id) REFERENCES users(id)
+    );
+  `);
+  return db;
+});
+
+const mockSession = vi.hoisted(() => ({
+  userId: undefined as number | undefined,
+  email: undefined as string | undefined,
+  displayName: undefined as string | undefined,
+  save: vi.fn(),
+  destroy: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ default: testDb }));
+
+vi.mock("@/lib/session", () => ({
+  getSession: vi.fn().mockResolvedValue(mockSession),
+  requireAuth: vi.fn().mockImplementation(async () => {
+    if (!mockSession.userId) return null;
+    return mockSession;
+  }),
+}));
+
+const { POST } = await import("@/app/api/listings/[id]/discord/route");
+
+function insertUser(email = "test@example.com", name = "Test User") {
+  testDb
+    .prepare("INSERT INTO users (email, password_hash, display_name) VALUES (?, ?, ?)")
+    .run(email, "hash", name);
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+function insertListing(
+  authorId: number,
+  overrides: Partial<{
+    is_full: number;
+    discord_link: string;
+  }> = {}
+) {
+  testDb
+    .prepare(
+      `INSERT INTO listings (author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size, is_full, discord_link)
+       VALUES (?, 'Test Book', 'Test Author', '1ch/wk', '2026-04-01', 'text', 5, ?, ?)`
+    )
+    .run(authorId, overrides.is_full ?? 0, overrides.discord_link ?? "");
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+describe("POST /api/listings/[id]/discord", () => {
+  beforeEach(() => {
+    testDb.exec("DELETE FROM listings");
+    testDb.exec("DELETE FROM users");
+    mockSession.userId = undefined;
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const req = createTestRequest("http://localhost:3000/api/listings/1/discord", {
+      method: "POST",
+      body: { discordLink: "https://discord.gg/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "1" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(401);
+  });
+
+  it("returns 400 for invalid listing ID", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    const req = createTestRequest("http://localhost:3000/api/listings/abc/discord", {
+      method: "POST",
+      body: { discordLink: "https://discord.gg/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "abc" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 404 when listing not found", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    const req = createTestRequest("http://localhost:3000/api/listings/999/discord", {
+      method: "POST",
+      body: { discordLink: "https://discord.gg/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "999" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(404);
+  });
+
+  it("returns 403 when user is not the author", async () => {
+    const authorId = insertUser("author@test.com", "Author");
+    const otherId = insertUser("other@test.com", "Other");
+    const listingId = insertListing(authorId, { is_full: 1 });
+    mockSession.userId = otherId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/discord`, {
+      method: "POST",
+      body: { discordLink: "https://discord.gg/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(403);
+  });
+
+  it("returns 400 when group is not full", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 0 });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/discord`, {
+      method: "POST",
+      body: { discordLink: "https://discord.gg/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 400 for invalid discord link", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockSession.userId = userId;
+
+    // Wrong prefix
+    let req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/discord`, {
+      method: "POST",
+      body: { discordLink: "https://example.com/invite" },
+    });
+    let res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    expect(res.status).toBe(400);
+
+    // Empty
+    req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/discord`, {
+      method: "POST",
+      body: { discordLink: "" },
+    });
+    res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts discord.gg link", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/discord`, {
+      method: "POST",
+      body: { discordLink: "https://discord.gg/abc123" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toEqual({ ok: true });
+
+    const listing = testDb.prepare("SELECT discord_link FROM listings WHERE id = ?").get(listingId) as { discord_link: string };
+    expect(listing.discord_link).toBe("https://discord.gg/abc123");
+  });
+
+  it("accepts discord.com/invite link", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/discord`, {
+      method: "POST",
+      body: { discordLink: "https://discord.com/invite/abc123" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toEqual({ ok: true });
+  });
+});

--- a/app/__tests__/api/listings/listing-telegram.test.ts
+++ b/app/__tests__/api/listings/listing-telegram.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest, parseResponse } from "../../helpers/mock-request";
+
+const testDb = vi.hoisted(() => {
+  const Db = require("better-sqlite3");
+  const db = new Db(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      bio TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS listings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      book_title TEXT NOT NULL,
+      book_author TEXT NOT NULL,
+      book_cover_url TEXT DEFAULT '',
+      book_olid TEXT DEFAULT '',
+      language TEXT DEFAULT 'English',
+      reading_pace TEXT NOT NULL,
+      start_date TEXT NOT NULL,
+      meeting_format TEXT NOT NULL CHECK(meeting_format IN ('voice', 'text', 'mixed')),
+      max_group_size INTEGER NOT NULL CHECK(max_group_size >= 2 AND max_group_size <= 20),
+      telegram_link TEXT DEFAULT '',
+      is_full INTEGER DEFAULT 0,
+      requires_approval INTEGER DEFAULT 0,
+      platform_preference TEXT DEFAULT 'telegram',
+      discord_link TEXT DEFAULT '',
+      discord_channel_id TEXT DEFAULT '',
+      telegram_chat_id INTEGER,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (author_id) REFERENCES users(id)
+    );
+  `);
+  return db;
+});
+
+const mockSession = vi.hoisted(() => ({
+  userId: undefined as number | undefined,
+  email: undefined as string | undefined,
+  displayName: undefined as string | undefined,
+  save: vi.fn(),
+  destroy: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ default: testDb }));
+
+vi.mock("@/lib/session", () => ({
+  getSession: vi.fn().mockResolvedValue(mockSession),
+  requireAuth: vi.fn().mockImplementation(async () => {
+    if (!mockSession.userId) return null;
+    return mockSession;
+  }),
+}));
+
+const { POST } = await import("@/app/api/listings/[id]/telegram/route");
+
+function insertUser(email = "test@example.com", name = "Test User") {
+  testDb
+    .prepare("INSERT INTO users (email, password_hash, display_name) VALUES (?, ?, ?)")
+    .run(email, "hash", name);
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+function insertListing(
+  authorId: number,
+  overrides: Partial<{
+    is_full: number;
+    telegram_link: string;
+  }> = {}
+) {
+  testDb
+    .prepare(
+      `INSERT INTO listings (author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size, is_full, telegram_link)
+       VALUES (?, 'Test Book', 'Test Author', '1ch/wk', '2026-04-01', 'text', 5, ?, ?)`
+    )
+    .run(authorId, overrides.is_full ?? 0, overrides.telegram_link ?? "");
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+describe("POST /api/listings/[id]/telegram", () => {
+  beforeEach(() => {
+    testDb.exec("DELETE FROM listings");
+    testDb.exec("DELETE FROM users");
+    mockSession.userId = undefined;
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const req = createTestRequest("http://localhost:3000/api/listings/1/telegram", {
+      method: "POST",
+      body: { telegramLink: "https://t.me/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "1" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(401);
+  });
+
+  it("returns 400 for invalid listing ID", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    const req = createTestRequest("http://localhost:3000/api/listings/abc/telegram", {
+      method: "POST",
+      body: { telegramLink: "https://t.me/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "abc" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 404 when listing not found", async () => {
+    const userId = insertUser();
+    mockSession.userId = userId;
+    const req = createTestRequest("http://localhost:3000/api/listings/999/telegram", {
+      method: "POST",
+      body: { telegramLink: "https://t.me/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "999" }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(404);
+  });
+
+  it("returns 403 when user is not the author", async () => {
+    const authorId = insertUser("author@test.com", "Author");
+    const otherId = insertUser("other@test.com", "Other");
+    const listingId = insertListing(authorId, { is_full: 1 });
+    mockSession.userId = otherId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/telegram`, {
+      method: "POST",
+      body: { telegramLink: "https://t.me/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(403);
+  });
+
+  it("returns 400 when group is not full", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 0 });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/telegram`, {
+      method: "POST",
+      body: { telegramLink: "https://t.me/test" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+  });
+
+  it("returns 400 for invalid telegram link", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockSession.userId = userId;
+
+    // Missing link
+    let req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/telegram`, {
+      method: "POST",
+      body: { telegramLink: "" },
+    });
+    let res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    expect(res.status).toBe(400);
+
+    // Wrong prefix
+    req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/telegram`, {
+      method: "POST",
+      body: { telegramLink: "https://example.com/group" },
+    });
+    res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("sets telegram link successfully", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    mockSession.userId = userId;
+    const req = createTestRequest(`http://localhost:3000/api/listings/${listingId}/telegram`, {
+      method: "POST",
+      body: { telegramLink: "https://t.me/+abcdef123" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: String(listingId) }) });
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toEqual({ ok: true });
+
+    const listing = testDb.prepare("SELECT telegram_link FROM listings WHERE id = ?").get(listingId) as { telegram_link: string };
+    expect(listing.telegram_link).toBe("https://t.me/+abcdef123");
+  });
+});

--- a/app/__tests__/api/telegram/telegram-setup.test.ts
+++ b/app/__tests__/api/telegram/telegram-setup.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest, parseResponse } from "../../helpers/mock-request";
+
+const mockTelegram = vi.hoisted(() => ({
+  isBotConfigured: vi.fn().mockReturnValue(true),
+  setWebhook: vi.fn().mockResolvedValue(true),
+  getBotInfo: vi.fn().mockResolvedValue({ id: 123, username: "BookmateBot", first_name: "Bookmate" }),
+}));
+
+vi.mock("@/lib/telegram", () => mockTelegram);
+
+const { POST, GET } = await import("@/app/api/telegram/setup/route");
+
+describe("POST /api/telegram/setup", () => {
+  beforeEach(() => {
+    vi.stubEnv("TELEGRAM_SETUP_SECRET", "test-secret");
+    vi.stubEnv("TELEGRAM_WEBHOOK_URL", "https://example.com/api/telegram/webhook");
+    mockTelegram.isBotConfigured.mockReturnValue(true);
+    mockTelegram.setWebhook.mockResolvedValue(true);
+    mockTelegram.getBotInfo.mockResolvedValue({ id: 123, username: "BookmateBot", first_name: "Bookmate" });
+  });
+
+  it("returns 500 when TELEGRAM_SETUP_SECRET is not configured", async () => {
+    vi.stubEnv("TELEGRAM_SETUP_SECRET", "");
+    const req = createTestRequest("http://localhost:3000/api/telegram/setup", {
+      method: "POST",
+      body: { secret: "anything" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+
+  it("returns 403 when secret is wrong", async () => {
+    const req = createTestRequest("http://localhost:3000/api/telegram/setup", {
+      method: "POST",
+      body: { secret: "wrong-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(403);
+  });
+
+  it("returns 500 when bot is not configured", async () => {
+    mockTelegram.isBotConfigured.mockReturnValue(false);
+    const req = createTestRequest("http://localhost:3000/api/telegram/setup", {
+      method: "POST",
+      body: { secret: "test-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+
+  it("returns 500 when TELEGRAM_WEBHOOK_URL is not configured", async () => {
+    vi.stubEnv("TELEGRAM_WEBHOOK_URL", "");
+    const req = createTestRequest("http://localhost:3000/api/telegram/setup", {
+      method: "POST",
+      body: { secret: "test-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+
+  it("returns 500 when getBotInfo fails", async () => {
+    mockTelegram.getBotInfo.mockResolvedValue(null);
+    const req = createTestRequest("http://localhost:3000/api/telegram/setup", {
+      method: "POST",
+      body: { secret: "test-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+
+  it("returns 500 when setWebhook fails", async () => {
+    mockTelegram.setWebhook.mockResolvedValue(false);
+    const req = createTestRequest("http://localhost:3000/api/telegram/setup", {
+      method: "POST",
+      body: { secret: "test-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+
+  it("sets up webhook successfully", async () => {
+    const req = createTestRequest("http://localhost:3000/api/telegram/setup", {
+      method: "POST",
+      body: { secret: "test-secret" },
+    });
+    const res = await POST(req);
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      ok: true,
+      bot: { username: "BookmateBot", id: 123 },
+      webhookUrl: "https://example.com/api/telegram/webhook",
+    });
+  });
+});
+
+describe("GET /api/telegram/setup", () => {
+  beforeEach(() => {
+    mockTelegram.isBotConfigured.mockReturnValue(true);
+    vi.stubEnv("TELEGRAM_WEBHOOK_URL", "https://example.com/api/telegram/webhook");
+  });
+
+  it("returns bot and webhook configuration status", async () => {
+    const res = await GET();
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toHaveProperty("botConfigured");
+    expect(data).toHaveProperty("webhookUrlConfigured");
+  });
+});

--- a/app/__tests__/api/telegram/telegram-webhook.test.ts
+++ b/app/__tests__/api/telegram/telegram-webhook.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTestRequest, parseResponse } from "../../helpers/mock-request";
+
+const testDb = vi.hoisted(() => {
+  const Db = require("better-sqlite3");
+  const db = new Db(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      bio TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS listings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      book_title TEXT NOT NULL,
+      book_author TEXT NOT NULL,
+      book_cover_url TEXT DEFAULT '',
+      book_olid TEXT DEFAULT '',
+      language TEXT DEFAULT 'English',
+      reading_pace TEXT NOT NULL,
+      start_date TEXT NOT NULL,
+      meeting_format TEXT NOT NULL CHECK(meeting_format IN ('voice', 'text', 'mixed')),
+      max_group_size INTEGER NOT NULL CHECK(max_group_size >= 2 AND max_group_size <= 20),
+      telegram_link TEXT DEFAULT '',
+      is_full INTEGER DEFAULT 0,
+      requires_approval INTEGER DEFAULT 0,
+      platform_preference TEXT DEFAULT 'telegram',
+      discord_link TEXT DEFAULT '',
+      discord_channel_id TEXT DEFAULT '',
+      telegram_chat_id INTEGER,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (author_id) REFERENCES users(id)
+    );
+    CREATE TABLE IF NOT EXISTS listing_members (
+      listing_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      joined_at TEXT DEFAULT (datetime('now')),
+      PRIMARY KEY (listing_id, user_id),
+      FOREIGN KEY (listing_id) REFERENCES listings(id),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+    CREATE TABLE IF NOT EXISTS notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      listing_id INTEGER,
+      type TEXT NOT NULL,
+      message TEXT NOT NULL,
+      is_read INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+    CREATE TABLE IF NOT EXISTS pending_telegram_groups (
+      listing_id INTEGER NOT NULL,
+      telegram_chat_id INTEGER NOT NULL,
+      created_at TEXT DEFAULT (datetime('now')),
+      PRIMARY KEY (listing_id)
+    );
+    CREATE TABLE IF NOT EXISTS telegram_chats (
+      chat_id INTEGER PRIMARY KEY,
+      chat_title TEXT DEFAULT '',
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS telegram_user_links (
+      user_id INTEGER NOT NULL,
+      telegram_user_id INTEGER NOT NULL,
+      PRIMARY KEY (user_id),
+      FOREIGN KEY (user_id) REFERENCES users(id)
+    );
+  `);
+  return db;
+});
+
+const mockTelegram = vi.hoisted(() => ({
+  createChatInviteLink: vi.fn().mockResolvedValue("https://t.me/+invite123"),
+  exportChatInviteLink: vi.fn().mockResolvedValue(null),
+  sendMessage: vi.fn().mockResolvedValue(true),
+  parseListingIdFromPayload: vi.fn().mockImplementation((payload: string) => {
+    const match = payload.match(/^listing_(\d+)$/);
+    return match ? parseInt(match[1], 10) : null;
+  }),
+}));
+
+vi.mock("@/lib/db", () => ({ default: testDb }));
+
+vi.mock("@/lib/telegram", () => mockTelegram);
+
+vi.mock("@/lib/notifications", () => ({
+  createNotification: vi.fn(),
+}));
+
+const { POST } = await import("@/app/api/telegram/webhook/route");
+
+function insertUser(email = "test@example.com", name = "Test User") {
+  testDb
+    .prepare("INSERT INTO users (email, password_hash, display_name) VALUES (?, ?, ?)")
+    .run(email, "hash", name);
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+function insertListing(
+  authorId: number,
+  overrides: Partial<{
+    is_full: number;
+    telegram_link: string;
+    book_title: string;
+  }> = {}
+) {
+  testDb
+    .prepare(
+      `INSERT INTO listings (author_id, book_title, book_author, reading_pace, start_date, meeting_format, max_group_size, is_full, telegram_link)
+       VALUES (?, ?, 'Test Author', '1ch/wk', '2026-04-01', 'text', 5, ?, ?)`
+    )
+    .run(authorId, overrides.book_title ?? "Test Book", overrides.is_full ?? 0, overrides.telegram_link ?? "");
+  return testDb.prepare("SELECT last_insert_rowid() as id").get().id as number;
+}
+
+function addMember(listingId: number, userId: number) {
+  testDb.prepare("INSERT INTO listing_members (listing_id, user_id) VALUES (?, ?)").run(listingId, userId);
+}
+
+describe("POST /api/telegram/webhook", () => {
+  beforeEach(() => {
+    testDb.exec("DELETE FROM listing_members");
+    testDb.exec("DELETE FROM notifications");
+    testDb.exec("DELETE FROM pending_telegram_groups");
+    testDb.exec("DELETE FROM telegram_chats");
+    testDb.exec("DELETE FROM telegram_user_links");
+    testDb.exec("DELETE FROM listings");
+    testDb.exec("DELETE FROM users");
+    vi.stubEnv("TELEGRAM_WEBHOOK_SECRET", "webhook-secret");
+    mockTelegram.createChatInviteLink.mockResolvedValue("https://t.me/+invite123");
+    mockTelegram.exportChatInviteLink.mockResolvedValue(null);
+    mockTelegram.sendMessage.mockResolvedValue(true);
+  });
+
+  it("returns 500 when webhook secret is not configured", async () => {
+    vi.stubEnv("TELEGRAM_WEBHOOK_SECRET", "");
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {},
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "anything" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(500);
+  });
+
+  it("returns 403 when secret header is wrong", async () => {
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {},
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "wrong-secret" },
+    });
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(403);
+  });
+
+  it("returns 200 for empty update (no action)", async () => {
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: { update_id: 1 },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+    const res = await POST(req);
+    const { status, data } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(data).toEqual({ ok: true });
+  });
+
+  it("handles /start command with listing payload", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    addMember(listingId, userId);
+
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 2,
+        message: {
+          chat: { id: -100123, type: "group", title: "Reading Group" },
+          text: `/start listing_${listingId}`,
+          from: { id: 456 },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+
+    // Verify telegram_link was set
+    const listing = testDb.prepare("SELECT telegram_link FROM listings WHERE id = ?").get(listingId) as { telegram_link: string };
+    expect(listing.telegram_link).toBe("https://t.me/+invite123");
+  });
+
+  it("handles pending_telegram_groups mapping via my_chat_member", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    addMember(listingId, userId);
+
+    // Insert pending mapping
+    testDb.prepare("INSERT INTO pending_telegram_groups (listing_id, telegram_chat_id) VALUES (?, ?)").run(listingId, -100999);
+
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 3,
+        my_chat_member: {
+          chat: { id: -100999, type: "group", title: "My Group" },
+          from: { id: 789, first_name: "Author" },
+          new_chat_member: {
+            user: { id: 111, is_bot: true },
+            status: "member",
+          },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+
+    // Verify listing was linked
+    const listing = testDb.prepare("SELECT telegram_link FROM listings WHERE id = ?").get(listingId) as { telegram_link: string };
+    expect(listing.telegram_link).toBe("https://t.me/+invite123");
+
+    // Verify pending mapping was deleted
+    const pending = testDb.prepare("SELECT * FROM pending_telegram_groups WHERE listing_id = ?").get(listingId);
+    expect(pending).toBeUndefined();
+  });
+
+  it("ignores my_chat_member when bot is not added as member/admin", async () => {
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 4,
+        my_chat_member: {
+          chat: { id: -100123, type: "group" },
+          from: { id: 789, first_name: "User" },
+          new_chat_member: {
+            user: { id: 111, is_bot: true },
+            status: "left",
+          },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+    // No crash, just silent ignore
+  });
+
+  it("handles /link command with linked user and single unlinked listing", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    addMember(listingId, userId);
+
+    // Link telegram user
+    testDb.prepare("INSERT INTO telegram_user_links (user_id, telegram_user_id) VALUES (?, ?)").run(userId, 456);
+
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 5,
+        message: {
+          chat: { id: -100555, type: "group" },
+          text: "/link",
+          from: { id: 456 },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+
+    // Listing should be linked
+    const listing = testDb.prepare("SELECT telegram_link FROM listings WHERE id = ?").get(listingId) as { telegram_link: string };
+    expect(listing.telegram_link).toBe("https://t.me/+invite123");
+  });
+
+  it("handles /link command from unlinked telegram user", async () => {
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 6,
+        message: {
+          chat: { id: -100555, type: "group" },
+          text: "/link",
+          from: { id: 999 },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(mockTelegram.sendMessage).toHaveBeenCalledWith(
+      -100555,
+      expect.stringContaining("not linked")
+    );
+  });
+
+  it("handles /link_ID command with verified ownership", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    addMember(listingId, userId);
+    testDb.prepare("INSERT INTO telegram_user_links (user_id, telegram_user_id) VALUES (?, ?)").run(userId, 456);
+
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 7,
+        message: {
+          chat: { id: -100666, type: "group" },
+          text: `/link_${listingId}`,
+          from: { id: 456 },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+
+    const listing = testDb.prepare("SELECT telegram_link FROM listings WHERE id = ?").get(listingId) as { telegram_link: string };
+    expect(listing.telegram_link).toBe("https://t.me/+invite123");
+  });
+
+  it("rejects /link_ID from non-author", async () => {
+    const authorId = insertUser("author@test.com", "Author");
+    const otherId = insertUser("other@test.com", "Other");
+    const listingId = insertListing(authorId, { is_full: 1 });
+    testDb.prepare("INSERT INTO telegram_user_links (user_id, telegram_user_id) VALUES (?, ?)").run(otherId, 789);
+
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 8,
+        message: {
+          chat: { id: -100777, type: "group" },
+          text: `/link_${listingId}`,
+          from: { id: 789 },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(mockTelegram.sendMessage).toHaveBeenCalledWith(
+      -100777,
+      expect.stringContaining("only link Telegram groups to your own")
+    );
+  });
+
+  it("ignores non-group messages", async () => {
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 9,
+        message: {
+          chat: { id: 123, type: "private" },
+          text: "/link",
+          from: { id: 456 },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+    // No action taken for private chats
+  });
+
+  it("uses fallback exportChatInviteLink when createChatInviteLink fails", async () => {
+    const userId = insertUser();
+    const listingId = insertListing(userId, { is_full: 1 });
+    addMember(listingId, userId);
+
+    mockTelegram.createChatInviteLink.mockResolvedValue(null);
+    mockTelegram.exportChatInviteLink.mockResolvedValue("https://t.me/+fallback");
+
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 10,
+        message: {
+          chat: { id: -100888, type: "supergroup" },
+          text: `/start listing_${listingId}`,
+          from: { id: 456 },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const listing = testDb.prepare("SELECT telegram_link FROM listings WHERE id = ?").get(listingId) as { telegram_link: string };
+    expect(listing.telegram_link).toBe("https://t.me/+fallback");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 69 new tests across 8 previously untested Telegram and Discord route files
- Total test count: 128 → 197 (54% increase)
- All tests pass, lint clean, build passes

### Routes covered:
- `POST /api/listings/[id]/telegram` — manual Telegram link setting (7 tests)
- `POST /api/listings/[id]/discord` — manual Discord link setting (8 tests)
- `GET /api/listings/[id]/auto-telegram` — deep link generation (9 tests)
- `GET /api/listings/[id]/auto-discord` — bot invite URL (8 tests)
- `POST/GET /api/telegram/setup` — webhook configuration (8 tests)
- `POST /api/telegram/webhook` — event handler: /start, /link, /link_ID, my_chat_member (11 tests)
- `POST /api/discord/setup` — bot verification (5 tests)
- `POST /api/discord/webhook` — channel creation, linking, PING/PONG (11 tests)

Closes #84

## Test plan
- [x] All 197 tests pass
- [x] ESLint clean (zero warnings)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)