### PR TITLE
Fix: logout, is_full reset, email subjects, webhook validation, fetch abort

### DIFF
--- a/app/app/api/auth/logout/route.ts
+++ b/app/app/api/auth/logout/route.ts
@@ -3,6 +3,6 @@ import { getSession } from "@/lib/session";
 
 export async function POST() {
   const session = await getSession();
-  session.destroy();
+  await session.destroy();
   return NextResponse.json({ ok: true });
 }

--- a/app/app/api/auth/me/route.ts
+++ b/app/app/api/auth/me/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
     | undefined;
 
   if (!user) {
-    session.destroy();
+    await session.destroy();
     return NextResponse.json({ user: null });
   }
 

--- a/app/app/api/discord/webhook/route.ts
+++ b/app/app/api/discord/webhook/route.ts
@@ -67,6 +67,13 @@ async function handleLink(body: {
     );
   }
 
+  if (typeof listingId !== "number" || !Number.isInteger(listingId) || listingId < 1) {
+    return NextResponse.json(
+      { error: "Invalid listingId" },
+      { status: 400 }
+    );
+  }
+
   const listing = db
     .prepare("SELECT * FROM listings WHERE id = ?")
     .get(listingId) as Record<string, unknown> | undefined;

--- a/app/app/api/listings/[id]/route.ts
+++ b/app/app/api/listings/[id]/route.ts
@@ -224,8 +224,18 @@ export async function PATCH(
       values.push(meetingFormat);
     }
     if (maxGroupSize !== undefined) {
+      const newSize = parseInt(maxGroupSize, 10);
       updates.push("max_group_size = ?");
-      values.push(parseInt(maxGroupSize, 10));
+      values.push(newSize);
+
+      // If increasing group size on a full listing, reopen it
+      const currentMemberCount = (db
+        .prepare("SELECT COUNT(*) as count FROM listing_members WHERE listing_id = ?")
+        .get(listingId) as { count: number }).count;
+      if (newSize > currentMemberCount && listing.is_full) {
+        updates.push("is_full = ?");
+        values.push(0);
+      }
     }
     if (requiresApproval !== undefined) {
       updates.push("requires_approval = ?");

--- a/app/components/BookSearch.tsx
+++ b/app/components/BookSearch.tsx
@@ -26,6 +26,7 @@ export default function BookSearch({ onSelect }: Props) {
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const abortRef = useRef<AbortController>(undefined);
   const containerRef = useRef<HTMLDivElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
 
@@ -49,26 +50,36 @@ export default function BookSearch({ onSelect }: Props) {
     }
 
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    if (abortRef.current) abortRef.current.abort();
+
+    const controller = new AbortController();
+    abortRef.current = controller;
 
     timeoutRef.current = setTimeout(async () => {
       setLoading(true);
       try {
         const res = await fetch(
-          `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=8&fields=key,title,author_name,cover_i`
+          `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=8&fields=key,title,author_name,cover_i`,
+          { signal: controller.signal }
         );
         const data = await res.json();
         setResults(data.docs || []);
         setOpen(true);
         setActiveIndex(-1);
-      } catch {
-        setResults([]);
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") {
+          setResults([]);
+        }
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
       }
     }, 400);
 
     return () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      controller.abort();
     };
   }, [query]);
 

--- a/app/lib/notifications.ts
+++ b/app/lib/notifications.ts
@@ -46,6 +46,10 @@ function getEmailSubject(type: string): string {
       return "Bookmate: A reading group has been cancelled";
     case "listing_updated":
       return "Bookmate: A reading group has been updated";
+    case "telegram_ready":
+      return "Bookmate: Your Telegram reading group is ready!";
+    case "discord_ready":
+      return "Bookmate: Your Discord channel is ready!";
     default:
       return "Bookmate: Notification";
   }


### PR DESCRIPTION
## Summary
Fixes 5 bugs found in code review round 6 (#86):

- **`session.destroy()` not awaited** — logout and stale-session cleanup never cleared the cookie, so users remained logged in until the 7-day session expiry
- **`is_full` not reset on group resize** — increasing `maxGroupSize` on a full listing left it permanently invisible in browse
- **Missing email subject cases** — `telegram_ready` and `discord_ready` notifications fell through to generic "Bookmate: Notification" subject
- **Discord webhook missing `listingId` validation** — accepted non-integer/negative values unlike the rest of the codebase
- **`BookSearch` fetch race condition** — added `AbortController` to cancel in-flight requests on unmount or rapid query changes

## Test plan
- [x] ESLint clean
- [x] 197 tests pass
- [x] Build passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)