### PR TITLE
fix: code review round 7 — HTML injection, auth bypass, validation

### DIFF
--- a/app/__tests__/api/discord/discord-webhook.test.ts
+++ b/app/__tests__/api/discord/discord-webhook.test.ts
@@ -63,6 +63,7 @@ const mockDiscord = vi.hoisted(() => ({
   createTextChannel: vi.fn().mockResolvedValue({ id: "ch-123", name: "bookmate-test-book" }),
   createChannelInvite: vi.fn().mockResolvedValue("https://discord.gg/abc123"),
   sendChannelMessage: vi.fn().mockResolvedValue(true),
+  isValidSnowflake: vi.fn().mockImplementation((id: string) => /^\d{17,20}$/.test(id)),
 }));
 
 vi.mock("@/lib/db", () => ({ default: testDb }));
@@ -175,7 +176,7 @@ describe("POST /api/discord/webhook", () => {
   it("returns 404 when listing not found", async () => {
     const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
       method: "POST",
-      body: { type: "link", guildId: "guild-1", listingId: 999 },
+      body: { type: "link", guildId: "12345678901234567", listingId: 999 },
       headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
     });
     const res = await POST(req);
@@ -188,7 +189,7 @@ describe("POST /api/discord/webhook", () => {
     const listingId = insertListing(userId, { is_full: 0 });
     const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
       method: "POST",
-      body: { type: "link", guildId: "guild-1", listingId },
+      body: { type: "link", guildId: "12345678901234567", listingId },
       headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
     });
     const res = await POST(req);
@@ -201,7 +202,7 @@ describe("POST /api/discord/webhook", () => {
     const listingId = insertListing(userId, { is_full: 1, discord_link: "https://discord.gg/existing" });
     const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
       method: "POST",
-      body: { type: "link", guildId: "guild-1", listingId },
+      body: { type: "link", guildId: "12345678901234567", listingId },
       headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
     });
     const res = await POST(req);
@@ -216,7 +217,7 @@ describe("POST /api/discord/webhook", () => {
 
     const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
       method: "POST",
-      body: { type: "link", guildId: "guild-1", listingId },
+      body: { type: "link", guildId: "12345678901234567", listingId },
       headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
     });
     const res = await POST(req);
@@ -241,7 +242,7 @@ describe("POST /api/discord/webhook", () => {
 
     const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
       method: "POST",
-      body: { type: "link", guildId: "guild-1", listingId, channelId: "existing-ch" },
+      body: { type: "link", guildId: "12345678901234567", listingId, channelId: "98765432109876543" },
       headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
     });
     const res = await POST(req);
@@ -252,7 +253,7 @@ describe("POST /api/discord/webhook", () => {
     expect(mockDiscord.createTextChannel).not.toHaveBeenCalled();
 
     // Should have created invite for the existing channel
-    expect(mockDiscord.createChannelInvite).toHaveBeenCalledWith("existing-ch");
+    expect(mockDiscord.createChannelInvite).toHaveBeenCalledWith("98765432109876543");
   });
 
   it("returns 500 when channel creation fails", async () => {
@@ -262,7 +263,7 @@ describe("POST /api/discord/webhook", () => {
 
     const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
       method: "POST",
-      body: { type: "link", guildId: "guild-1", listingId },
+      body: { type: "link", guildId: "12345678901234567", listingId },
       headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
     });
     const res = await POST(req);
@@ -277,7 +278,7 @@ describe("POST /api/discord/webhook", () => {
 
     const req = createTestRequest("http://localhost:3000/api/discord/webhook", {
       method: "POST",
-      body: { type: "link", guildId: "guild-1", listingId },
+      body: { type: "link", guildId: "12345678901234567", listingId },
       headers: { "X-Discord-Webhook-Secret": "discord-webhook-secret" },
     });
     const res = await POST(req);

--- a/app/__tests__/api/telegram/telegram-webhook.test.ts
+++ b/app/__tests__/api/telegram/telegram-webhook.test.ts
@@ -84,6 +84,9 @@ const mockTelegram = vi.hoisted(() => ({
     const match = payload.match(/^listing_(\d+)$/);
     return match ? parseInt(match[1], 10) : null;
   }),
+  escapeHtml: vi.fn().mockImplementation((text: string) =>
+    text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
+  ),
 }));
 
 vi.mock("@/lib/db", () => ({ default: testDb }));
@@ -174,10 +177,12 @@ describe("POST /api/telegram/webhook", () => {
     expect(data).toEqual({ ok: true });
   });
 
-  it("handles /start command with listing payload", async () => {
+  it("handles /start command with listing payload when sender is linked author", async () => {
     const userId = insertUser();
     const listingId = insertListing(userId, { is_full: 1 });
     addMember(listingId, userId);
+    // Link the telegram user to the listing author
+    testDb.prepare("INSERT INTO telegram_user_links (user_id, telegram_user_id) VALUES (?, ?)").run(userId, 456);
 
     const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
       method: "POST",
@@ -199,6 +204,42 @@ describe("POST /api/telegram/webhook", () => {
     // Verify telegram_link was set
     const listing = testDb.prepare("SELECT telegram_link FROM listings WHERE id = ?").get(listingId) as { telegram_link: string };
     expect(listing.telegram_link).toBe("https://t.me/+invite123");
+  });
+
+  it("rejects /start command when sender is not the listing author", async () => {
+    const authorId = insertUser("author@test.com", "Author");
+    const listingId = insertListing(authorId, { is_full: 1 });
+    addMember(listingId, authorId);
+    // Link a different user
+    const otherId = insertUser("other@test.com", "Other");
+    testDb.prepare("INSERT INTO telegram_user_links (user_id, telegram_user_id) VALUES (?, ?)").run(otherId, 789);
+
+    const req = createTestRequest("http://localhost:3000/api/telegram/webhook", {
+      method: "POST",
+      body: {
+        update_id: 2,
+        message: {
+          chat: { id: -100123, type: "group", title: "Reading Group" },
+          text: `/start listing_${listingId}`,
+          from: { id: 789 },
+        },
+      },
+      headers: { "X-Telegram-Bot-Api-Secret-Token": "webhook-secret" },
+    });
+
+    const res = await POST(req);
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+
+    // Listing should NOT be linked
+    const listing = testDb.prepare("SELECT telegram_link FROM listings WHERE id = ?").get(listingId) as { telegram_link: string };
+    expect(listing.telegram_link).toBe("");
+
+    // Should have sent a message about using /link
+    expect(mockTelegram.sendMessage).toHaveBeenCalledWith(
+      -100123,
+      expect.stringContaining("/link")
+    );
   });
 
   it("handles pending_telegram_groups mapping via my_chat_member", async () => {
@@ -393,6 +434,8 @@ describe("POST /api/telegram/webhook", () => {
     const userId = insertUser();
     const listingId = insertListing(userId, { is_full: 1 });
     addMember(listingId, userId);
+    // Link the telegram user to the author so /start succeeds
+    testDb.prepare("INSERT INTO telegram_user_links (user_id, telegram_user_id) VALUES (?, ?)").run(userId, 456);
 
     mockTelegram.createChatInviteLink.mockResolvedValue(null);
     mockTelegram.exportChatInviteLink.mockResolvedValue("https://t.me/+fallback");

--- a/app/app/api/discord/webhook/route.ts
+++ b/app/app/api/discord/webhook/route.ts
@@ -4,6 +4,7 @@ import {
   createTextChannel,
   createChannelInvite,
   sendChannelMessage,
+  isValidSnowflake,
 } from "@/lib/discord";
 import { createNotification } from "@/lib/notifications";
 
@@ -70,6 +71,20 @@ async function handleLink(body: {
   if (typeof listingId !== "number" || !Number.isInteger(listingId) || listingId < 1) {
     return NextResponse.json(
       { error: "Invalid listingId" },
+      { status: 400 }
+    );
+  }
+
+  // Validate Discord snowflake IDs to prevent path traversal in API URLs
+  if (typeof guildId !== "string" || !isValidSnowflake(guildId)) {
+    return NextResponse.json(
+      { error: "Invalid guildId format" },
+      { status: 400 }
+    );
+  }
+  if (channelId !== undefined && (typeof channelId !== "string" || !isValidSnowflake(channelId))) {
+    return NextResponse.json(
+      { error: "Invalid channelId format" },
       { status: 400 }
     );
   }

--- a/app/app/api/profile/reading/route.ts
+++ b/app/app/api/profile/reading/route.ts
@@ -12,6 +12,7 @@ interface ReadingRow {
   meeting_format: string;
   is_full: number;
   telegram_link: string;
+  discord_link: string;
   member_count: number;
   max_group_size: number;
   author_name: string;
@@ -36,6 +37,7 @@ export async function GET() {
       l.meeting_format,
       l.is_full,
       l.telegram_link,
+      l.discord_link,
       l.max_group_size,
       u.display_name as author_name,
       lm.joined_at,

--- a/app/app/api/telegram/webhook/route.ts
+++ b/app/app/api/telegram/webhook/route.ts
@@ -5,6 +5,7 @@ import {
   exportChatInviteLink,
   sendMessage,
   parseListingIdFromPayload,
+  escapeHtml,
 } from "@/lib/telegram";
 import { createNotification } from "@/lib/notifications";
 
@@ -165,7 +166,33 @@ async function handleMessage(message: TelegramMessage) {
     const payload = text.replace("/start ", "").trim();
     const listingId = parseListingIdFromPayload(payload);
     if (listingId) {
-      await linkTelegramToListing(listingId, message.chat.id);
+      // Verify the sender is the listing author to prevent unauthorized linking
+      const telegramUserId = message.from?.id;
+      if (!telegramUserId) {
+        await sendMessage(message.chat.id, "Could not identify the sender.");
+        return;
+      }
+
+      const linkedUser = db
+        .prepare("SELECT user_id FROM telegram_user_links WHERE telegram_user_id = ?")
+        .get(telegramUserId) as { user_id: number } | undefined;
+
+      if (linkedUser) {
+        const listing = db
+          .prepare("SELECT author_id FROM listings WHERE id = ?")
+          .get(listingId) as { author_id: number } | undefined;
+
+        if (listing && listing.author_id === linkedUser.user_id) {
+          await linkTelegramToListing(listingId, message.chat.id);
+          return;
+        }
+      }
+
+      // If no linked user or not the author, store for later linking via /link command
+      await sendMessage(
+        message.chat.id,
+        "To link this group to a Bookmate listing, the listing author should use the <code>/link</code> command."
+      );
       return;
     }
   }
@@ -218,7 +245,7 @@ async function handleMessage(message: TelegramMessage) {
     }
 
     const listText = unlinkedListings
-      .map((l) => `  /link_${l.id} — "${l.book_title}"`)
+      .map((l) => `  /link_${l.id} — "${escapeHtml(l.book_title)}"`)
       .join("\n");
     await sendMessage(
       message.chat.id,
@@ -334,9 +361,10 @@ async function linkTelegramToListing(listingId: number, chatId: number) {
   }
 
   // Send confirmation to the Telegram group
+  // Escape book title to prevent HTML injection via Telegram's HTML parser
   await sendMessage(
     chatId,
-    `This group is now linked to the Bookmate reading group for "<b>${bookTitle}</b>".\n\n` +
+    `This group is now linked to the Bookmate reading group for "<b>${escapeHtml(bookTitle)}</b>".\n\n` +
       `Invite link: ${inviteLink}\n\n` +
       "All group members have been notified on Bookmate. Happy reading!"
   );

--- a/app/lib/discord.ts
+++ b/app/lib/discord.ts
@@ -22,6 +22,14 @@ export function isBotConfigured(): boolean {
 }
 
 /**
+ * Validate a Discord snowflake ID (numeric string, 17-20 digits).
+ * Used to prevent path traversal in Discord API URL construction.
+ */
+export function isValidSnowflake(id: string): boolean {
+  return /^\d{17,20}$/.test(id);
+}
+
+/**
  * Call the Discord REST API.
  */
 async function callApi<T = unknown>(

--- a/app/lib/telegram.ts
+++ b/app/lib/telegram.ts
@@ -104,6 +104,19 @@ export async function exportChatInviteLink(
 }
 
 /**
+ * Escape HTML special characters for Telegram HTML parse mode.
+ * Telegram's HTML parser interprets <, >, &, and " — all must be escaped
+ * in user-supplied content to prevent message injection.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
  * Send a message to a Telegram chat.
  */
 export async function sendMessage(


### PR DESCRIPTION
## Summary
- **HTML injection in Telegram messages** — Book titles were interpolated directly into HTML-mode Telegram messages. Added `escapeHtml()` to sanitize `<`, `>`, `&`, `"` characters before sending.
- **Telegram /start auth bypass** — `/start listing_ID` command linked any group to any listing without checking ownership. Now verifies the sender is the listing author via `telegram_user_links`.
- **Discord ID path traversal** — `guildId` and `channelId` were used unvalidated in Discord API URL paths. Added snowflake format validation (17-20 digit numeric strings).
- **Missing discord_link in profile** — Profile reading API returned `telegram_link` but not `discord_link`. Added to query and interface.

Closes #88

## Test plan
- [x] All 198 tests pass (1 new test for /start rejection)
- [x] ESLint clean
- [x] Build passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)