### PR TITLE
fix: code review round 8 — timing-safe secrets, type validation, stale data

### DIFF
--- a/app/app/api/discord/setup/route.ts
+++ b/app/app/api/discord/setup/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isBotConfigured, getBotInfo } from "@/lib/discord";
+import { safeCompare } from "@/lib/crypto-utils";
 
 /**
  * Discord bot setup endpoint.
@@ -11,7 +12,7 @@ export async function POST(req: NextRequest) {
   const { secret } = await req.json();
   const setupSecret = process.env.DISCORD_SETUP_SECRET || "";
 
-  if (!setupSecret || secret !== setupSecret) {
+  if (!setupSecret || !secret || typeof secret !== "string" || !safeCompare(secret, setupSecret)) {
     return NextResponse.json(
       { error: "Invalid setup secret" },
       { status: 403 }

--- a/app/app/api/discord/webhook/route.ts
+++ b/app/app/api/discord/webhook/route.ts
@@ -7,6 +7,7 @@ import {
   isValidSnowflake,
 } from "@/lib/discord";
 import { createNotification } from "@/lib/notifications";
+import { safeCompare } from "@/lib/crypto-utils";
 
 /**
  * Discord webhook endpoint for bot events.
@@ -26,7 +27,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
   }
   const headerSecret = req.headers.get("X-Discord-Webhook-Secret");
-  if (headerSecret !== webhookSecret) {
+  if (!headerSecret || !safeCompare(headerSecret, webhookSecret)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
   }
 

--- a/app/app/api/listings/[id]/join/route.ts
+++ b/app/app/api/listings/[id]/join/route.ts
@@ -68,13 +68,22 @@ export async function POST(
   }
 
   // Wrap count check + insert in a transaction to prevent race conditions
+  // Re-read max_group_size inside the transaction to avoid stale data from concurrent PATCH
   const joinTransaction = db.transaction(() => {
+    const freshListing = db
+      .prepare("SELECT max_group_size FROM listings WHERE id = ?")
+      .get(listingId) as { max_group_size: number } | undefined;
+
+    if (!freshListing) {
+      return { error: "Listing not found", count: 0, maxSize: 0 };
+    }
+
     const { count } = db
       .prepare("SELECT COUNT(*) as count FROM listing_members WHERE listing_id = ?")
       .get(listingId) as { count: number };
 
-    if (count >= (listing.max_group_size as number)) {
-      return { error: "This group is already full", count };
+    if (count >= freshListing.max_group_size) {
+      return { error: "This group is already full", count, maxSize: freshListing.max_group_size };
     }
 
     db.prepare(
@@ -82,11 +91,11 @@ export async function POST(
     ).run(listingId, session.userId);
 
     const newCount = count + 1;
-    if (newCount >= (listing.max_group_size as number)) {
+    if (newCount >= freshListing.max_group_size) {
       db.prepare("UPDATE listings SET is_full = 1 WHERE id = ?").run(listingId);
     }
 
-    return { error: null, count: newCount };
+    return { error: null, count: newCount, maxSize: freshListing.max_group_size };
   });
 
   const result = joinTransaction();
@@ -98,7 +107,7 @@ export async function POST(
   // Notify outside the transaction (fire-and-forget)
   notifyListingAuthor(listingId, session.displayName || "Someone");
 
-  if (result.count === (listing.max_group_size as number)) {
+  if (result.count === result.maxSize) {
     notifyGroupFull(listingId);
   }
 

--- a/app/app/api/listings/[id]/route.ts
+++ b/app/app/api/listings/[id]/route.ts
@@ -157,13 +157,13 @@ export async function PATCH(
       platformPreference,
     } = body;
 
-    // Validate fields that are provided
-    if (readingPace !== undefined && (!readingPace || readingPace.length > 200)) {
+    // Validate fields that are provided — type check before string operations
+    if (readingPace !== undefined && (typeof readingPace !== "string" || !readingPace || readingPace.length > 200)) {
       return NextResponse.json({ error: "Reading pace is required (max 200 characters)" }, { status: 400 });
     }
 
     if (startDate !== undefined) {
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+      if (typeof startDate !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
         return NextResponse.json({ error: "Invalid start date format (expected YYYY-MM-DD)" }, { status: 400 });
       }
       const today = new Date().toISOString().split("T")[0];
@@ -172,12 +172,15 @@ export async function PATCH(
       }
     }
 
-    if (meetingFormat !== undefined && !["voice", "text", "mixed"].includes(meetingFormat)) {
+    if (meetingFormat !== undefined && (typeof meetingFormat !== "string" || !["voice", "text", "mixed"].includes(meetingFormat))) {
       return NextResponse.json({ error: "Invalid meeting format" }, { status: 400 });
     }
 
     if (maxGroupSize !== undefined) {
-      const size = parseInt(maxGroupSize, 10);
+      if (typeof maxGroupSize !== "number" && typeof maxGroupSize !== "string") {
+        return NextResponse.json({ error: "Invalid group size type" }, { status: 400 });
+      }
+      const size = parseInt(String(maxGroupSize), 10);
       if (isNaN(size) || size < 2 || size > 20) {
         return NextResponse.json({ error: "Group size must be between 2 and 20" }, { status: 400 });
       }

--- a/app/app/api/listings/create/route.ts
+++ b/app/app/api/listings/create/route.ts
@@ -42,6 +42,23 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Type check all string fields to prevent coercion bypasses
+    if (typeof bookTitle !== "string" || typeof bookAuthor !== "string" ||
+        typeof readingPace !== "string" || typeof startDate !== "string" ||
+        typeof meetingFormat !== "string") {
+      return NextResponse.json(
+        { error: "Invalid field types" },
+        { status: 400 }
+      );
+    }
+
+    if (typeof maxGroupSize !== "number" && typeof maxGroupSize !== "string") {
+      return NextResponse.json(
+        { error: "Invalid group size" },
+        { status: 400 }
+      );
+    }
+
     // Input length limits to prevent abuse
     if (bookTitle.length > 300 || bookAuthor.length > 200 || readingPace.length > 200) {
       return NextResponse.json(
@@ -72,7 +89,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const size = parseInt(maxGroupSize, 10);
+    const size = parseInt(String(maxGroupSize), 10);
     if (isNaN(size) || size < 2 || size > 20) {
       return NextResponse.json(
         { error: "Group size must be between 2 and 20" },

--- a/app/app/api/telegram/setup/route.ts
+++ b/app/app/api/telegram/setup/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isBotConfigured, setWebhook, getBotInfo } from "@/lib/telegram";
+import { safeCompare } from "@/lib/crypto-utils";
 
 /**
  * POST /api/telegram/setup
@@ -19,7 +20,7 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json();
-  if (body.secret !== setupSecret) {
+  if (!body.secret || typeof body.secret !== "string" || !safeCompare(body.secret, setupSecret)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
   }
 

--- a/app/app/api/telegram/webhook/route.ts
+++ b/app/app/api/telegram/webhook/route.ts
@@ -8,6 +8,7 @@ import {
   escapeHtml,
 } from "@/lib/telegram";
 import { createNotification } from "@/lib/notifications";
+import { safeCompare } from "@/lib/crypto-utils";
 
 /**
  * Telegram webhook endpoint.
@@ -29,7 +30,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
   }
   const headerSecret = req.headers.get("X-Telegram-Bot-Api-Secret-Token");
-  if (headerSecret !== webhookSecret) {
+  if (!headerSecret || !safeCompare(headerSecret, webhookSecret)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
   }
 

--- a/app/lib/crypto-utils.ts
+++ b/app/lib/crypto-utils.ts
@@ -1,0 +1,28 @@
+import { timingSafeEqual } from "crypto";
+
+/**
+ * Constant-time string comparison to prevent timing side-channel attacks.
+ * Use this for comparing secrets (webhook tokens, setup secrets, etc.)
+ */
+export function safeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Still do a comparison to avoid leaking length info via timing
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Escape user-controlled content for safe embedding in HTML emails.
+ */
+export function escapeHtmlForEmail(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/app/lib/notifications.ts
+++ b/app/lib/notifications.ts
@@ -1,5 +1,6 @@
 import db from "./db";
 import { sendEmail } from "./email";
+import { escapeHtmlForEmail } from "./crypto-utils";
 
 function getUserEmail(userId: number): string | null {
   const user = db
@@ -22,7 +23,10 @@ export function createNotification(
   const email = getUserEmail(userId);
   if (email) {
     const subject = getEmailSubject(type);
-    sendEmail(email, subject, message).catch(() => {
+    // HTML-escape the message to prevent injection via user-controlled content
+    // (display names, book titles) embedded in notification messages
+    const htmlBody = `<p>${escapeHtmlForEmail(message)}</p>`;
+    sendEmail(email, subject, message, htmlBody).catch(() => {
       // Email sending is best-effort — don't block on failure
     });
   }


### PR DESCRIPTION
## Summary
- **Timing-safe secret comparison**: All 4 webhook/setup endpoints now use `crypto.timingSafeEqual` instead of `!==` to prevent timing oracle attacks on secret tokens
- **Input type validation**: Added `typeof` guards for all JSON body fields (`maxGroupSize`, `readingPace`, `startDate`, `meetingFormat`) in create and PATCH routes to prevent type coercion bypasses
- **Stale transaction data**: Join route now re-reads `max_group_size` inside the transaction to prevent a concurrent PATCH from changing the limit between the outer read and the transaction
- **Email HTML escaping**: Notification messages containing user-controlled content (display names, book titles) are now HTML-escaped before embedding in email body

Closes #90

## Test plan
- [x] All 198 existing tests pass
- [x] Build succeeds
- [x] Lint clean
- [ ] CI pipeline validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)