### PR TITLE
fix: client-side race conditions, date bugs, error handling, ARIA

### DIFF
--- a/app/app/listings/[id]/ListingDetail.tsx
+++ b/app/app/listings/[id]/ListingDetail.tsx
@@ -458,7 +458,7 @@ export default function ListingDetail() {
             </p>
 
             <div className="flex flex-wrap gap-2 mb-3">
-              {new Date(listing.start_date) < new Date(new Date().toISOString().split("T")[0]) && (
+              {new Date(listing.start_date + "T00:00:00") < new Date(new Date().toISOString().split("T")[0] + "T00:00:00") && (
                 <span
                   className="badge"
                   style={{
@@ -501,7 +501,7 @@ export default function ListingDetail() {
                   Starts
                 </span>
                 <div className="font-semibold">
-                  {new Date(listing.start_date).toLocaleDateString("en-US", {
+                  {new Date(listing.start_date + "T00:00:00").toLocaleDateString("en-US", {
                     month: "long",
                     day: "numeric",
                     year: "numeric",

--- a/app/app/listings/[id]/edit/page.tsx
+++ b/app/app/listings/[id]/edit/page.tsx
@@ -10,6 +10,7 @@ export default function EditListingPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [fetching, setFetching] = useState(true);
+  const [fetchFailed, setFetchFailed] = useState(false);
 
   const [bookTitle, setBookTitle] = useState("");
   const [bookAuthor, setBookAuthor] = useState("");
@@ -54,9 +55,11 @@ export default function EditListingPage() {
           router.push("/auth/login");
         } else {
           setError("Listing not found");
+          setFetchFailed(true);
         }
       } catch {
         setError("Failed to load listing");
+        setFetchFailed(true);
       } finally {
         setFetching(false);
       }
@@ -120,6 +123,32 @@ export default function EditListingPage() {
     (n) => n >= memberCount
   );
 
+  // Don't render the form if the fetch failed — prevents submitting default values
+  if (fetchFailed) {
+    return (
+      <div className="max-w-lg mx-auto">
+        <h1 className="text-2xl sm:text-3xl mb-2">Edit reading group</h1>
+        <div
+          className="mb-4 p-3 rounded-lg text-sm"
+          style={{
+            backgroundColor: "rgba(192, 57, 43, 0.08)",
+            color: "var(--color-error)",
+            fontFamily: "system-ui, sans-serif",
+          }}
+          role="alert"
+        >
+          {error}
+        </div>
+        <button
+          className="btn-secondary"
+          onClick={() => router.push(`/listings/${id}`)}
+        >
+          Back to listing
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="max-w-lg mx-auto">
       <h1 className="text-2xl sm:text-3xl mb-2">Edit reading group</h1>
@@ -163,6 +192,7 @@ export default function EditListingPage() {
             width={48}
             height={68}
             className="w-12 h-17 object-cover rounded"
+            unoptimized
           />
         )}
         <div>

--- a/app/app/listings/create/page.tsx
+++ b/app/app/listings/create/page.tsx
@@ -126,6 +126,7 @@ export default function CreateListingPage() {
                   width={40}
                   height={56}
                   className="w-10 h-14 object-cover rounded"
+                  unoptimized
                 />
               )}
               <div>

--- a/app/app/notifications/page.tsx
+++ b/app/app/notifications/page.tsx
@@ -16,19 +16,28 @@ interface Notification {
 export default function NotificationsPage() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/notifications")
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load notifications");
+        return r.json();
+      })
       .then((data) => {
         setNotifications(data.notifications || []);
-        setLoading(false);
-        // Mark all as read
+        // Mark all as read (fire-and-forget with silent catch)
         fetch("/api/notifications", {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({}),
-        });
+        }).catch(() => {});
+      })
+      .catch(() => {
+        setError("Could not load notifications. Please try again.");
+      })
+      .finally(() => {
+        setLoading(false);
       });
   }, []);
 
@@ -36,6 +45,29 @@ export default function NotificationsPage() {
     return (
       <div className="text-center py-16" style={{ color: "var(--color-text-secondary)" }}>
         <p style={{ fontFamily: "system-ui, sans-serif" }}>Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl sm:text-3xl mb-4 sm:mb-6">Notifications</h1>
+        <div className="text-center py-12">
+          <p
+            className="text-sm mb-4"
+            style={{ color: "var(--color-error)", fontFamily: "system-ui, sans-serif" }}
+            role="alert"
+          >
+            {error}
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            className="btn-primary"
+          >
+            Try again
+          </button>
+        </div>
       </div>
     );
   }

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -40,9 +40,15 @@ export default function HomePage() {
   const [totalResults, setTotalResults] = useState(0);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const abortRef = useRef<AbortController>(undefined);
 
   const fetchListings = useCallback(
     (query: string, format: string, sortBy: string, pace?: string, dateFrom?: string, pageNum?: number) => {
+      // Abort any in-flight request to prevent stale responses overwriting newer ones
+      if (abortRef.current) abortRef.current.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
       setLoading(true);
       const params = new URLSearchParams();
       if (query) params.set("q", query);
@@ -53,12 +59,13 @@ export default function HomePage() {
       if (pageNum && pageNum > 1) params.set("page", String(pageNum));
 
       const qs = params.toString();
-      fetch(`/api/listings${qs ? `?${qs}` : ""}`)
+      fetch(`/api/listings${qs ? `?${qs}` : ""}`, { signal: controller.signal })
         .then((r) => {
           if (!r.ok) throw new Error("Failed to load listings");
           return r.json();
         })
         .then((data) => {
+          if (controller.signal.aborted) return;
           setListings(data.listings || []);
           if (data.pagination) {
             setTotalPages(data.pagination.totalPages || 1);
@@ -68,6 +75,7 @@ export default function HomePage() {
           setLoading(false);
         })
         .catch((err) => {
+          if ((err as Error).name === "AbortError") return;
           setError(err.message || "Could not load listings. Please try again.");
           setLoading(false);
         });
@@ -562,7 +570,7 @@ export default function HomePage() {
                       }}
                     >
                       Starts{" "}
-                      {new Date(listing.start_date).toLocaleDateString(
+                      {new Date(listing.start_date + "T00:00:00").toLocaleDateString(
                         "en-US",
                         {
                           month: "short",

--- a/app/app/profile/page.tsx
+++ b/app/app/profile/page.tsx
@@ -83,7 +83,8 @@ export default function ProfilePage() {
         setLoading(false);
       })
       .catch(() => {
-        setLoading(false);
+        // Network error — can't verify auth, redirect to login
+        router.push("/auth/login");
       });
   }, [router]);
 
@@ -198,7 +199,8 @@ export default function ProfilePage() {
   ];
 
   const formatDate = (dateStr: string) => {
-    const d = new Date(dateStr);
+    // Append T00:00:00 for date-only strings to prevent UTC-offset date shifts
+    const d = dateStr.length === 10 ? new Date(dateStr + "T00:00:00") : new Date(dateStr);
     return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
   };
 

--- a/app/components/BookSearch.tsx
+++ b/app/components/BookSearch.tsx
@@ -177,10 +177,9 @@ export default function BookSearch({ onSelect }: Props) {
           style={{ padding: "0.5rem 0" }}
         >
           {results.map((book, index) => (
-            <button
+            <div
               key={book.key}
               id={`book-option-${book.key}`}
-              type="button"
               role="option"
               aria-selected={index === activeIndex}
               onClick={() => handleSelect(book)}
@@ -223,7 +222,7 @@ export default function BookSearch({ onSelect }: Props) {
                   {book.author_name?.[0] || "Unknown author"}
                 </div>
               </div>
-            </button>
+            </div>
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- **Race condition in `fetchListings`** — Added `AbortController` to cancel in-flight requests when new ones are triggered, preventing stale responses from overwriting newer results
- **Date off-by-one in negative UTC timezones** — `new Date("2026-04-01")` parses as UTC midnight, showing March 31 in timezones west of UTC. Fixed by appending `T00:00:00` for local time interpretation
- **Raw `<Image>` without `unoptimized`** in create/edit pages — Now consistent with `BookCover` component pattern, prevents runtime errors on unexpected cover URLs
- **Notifications infinite loading on fetch error** — Added `.catch()` and error UI with retry button
- **Invalid ARIA `<button role="option">`** in BookSearch — Changed to `<div role="option">` for valid listbox pattern (screen reader compatibility)
- **Edit page form submittable with default values on fetch error** — Now shows error message + back button instead of the form
- **Profile auth guard network error** — Redirects to login instead of showing blank form

Closes #92

## Test plan
- [x] ESLint clean
- [x] 198 tests pass
- [x] Build passes
- [ ] Verify rapid filter changes on browse page don't show stale results
- [ ] Verify dates display correctly in UTC-negative timezones
- [ ] Verify notifications page shows error on network failure
- [ ] Verify edit page shows error (not form) when listing fetch fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)