### PR TITLE
fix: code review round 11 — stale data, unmount cleanup, duplicate notifications

### DIFF
--- a/app/app/api/listings/[id]/applications/route.ts
+++ b/app/app/api/listings/[id]/applications/route.ts
@@ -59,12 +59,21 @@ export async function PATCH(
   if (action === "approve") {
     // Use transaction to ensure atomicity
     const approveTransaction = db.transaction(() => {
+      // Re-read max_group_size inside transaction to avoid stale data from concurrent PATCH
+      const freshListing = db
+        .prepare("SELECT max_group_size FROM listings WHERE id = ?")
+        .get(listingId) as { max_group_size: number } | undefined;
+
+      if (!freshListing) {
+        throw new Error("Listing not found");
+      }
+
       // Check if group is already full
       const { count } = db
         .prepare("SELECT COUNT(*) as count FROM listing_members WHERE listing_id = ?")
         .get(listingId) as { count: number };
 
-      if (count >= (listing.max_group_size as number)) {
+      if (count >= freshListing.max_group_size) {
         throw new Error("Group is already full");
       }
 
@@ -81,7 +90,7 @@ export async function PATCH(
       // Check if group is now full
       const newCount = count + 1;
       let rejectedApps: { id: number; user_id: number }[] = [];
-      if (newCount >= (listing.max_group_size as number)) {
+      if (newCount >= freshListing.max_group_size) {
         db.prepare("UPDATE listings SET is_full = 1 WHERE id = ?").run(listingId);
 
         // Reject remaining pending applications inside the transaction

--- a/app/app/api/listings/[id]/join/route.ts
+++ b/app/app/api/listings/[id]/join/route.ts
@@ -105,10 +105,12 @@ export async function POST(
   }
 
   // Notify outside the transaction (fire-and-forget)
-  notifyListingAuthor(listingId, session.displayName || "Someone");
-
+  // When group just filled, skip new_member notification for the author
+  // since they'll receive the more important group_full notification instead
   if (result.count === result.maxSize) {
     notifyGroupFull(listingId);
+  } else {
+    notifyListingAuthor(listingId, session.displayName || "Someone");
   }
 
   return NextResponse.json({ ok: true, memberCount: result.count });

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -88,6 +88,14 @@ export default function HomePage() {
     fetchListings("", "", "newest", "", "", 1);
   }, [fetchListings]);
 
+  // Cleanup debounce timer and in-flight request on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, []);
+
   // Debounced search
   const handleSearchChange = (value: string) => {
     setSearchQuery(value);


### PR DESCRIPTION
## Summary
- **Stale `max_group_size` in approve transaction** (CRITICAL) — The applications route read `max_group_size` outside the transaction and used the stale value inside. A concurrent PATCH could change it, allowing extra members. Now re-reads inside the transaction, matching the join route pattern.
- **Missing `useEffect` cleanup on HomePage** (IMPORTANT) — Debounce timer and AbortController were not cleaned up on unmount, leaving orphaned fetches after navigation. Added cleanup effect.
- **Duplicate author notifications on group fill** (IMPORTANT) — Author received both `new_member` and `group_full` when last person joined. Now only sends `group_full` which is more informative.

Closes #96

## Test plan
- [x] All 198 tests pass
- [x] ESLint clean
- [x] Build passes
- [ ] Verify approve flow still works correctly with transaction fix
- [ ] Verify HomePage navigation doesn't leave orphaned fetches
- [ ] Verify author gets single notification when group fills

🤖 Generated with [Claude Code](https://claude.com/claude-code)