### PR TITLE
fix: PATCH race condition, strip internal platform IDs (#98)

### DIFF
--- a/app/app/api/listings/[id]/route.ts
+++ b/app/app/api/listings/[id]/route.ts
@@ -86,9 +86,13 @@ export async function GET(
       .all(listingId) as { application_id: number; id: number; display_name: string; bio: string; applied_at: string }[];
   }
 
-  // Strip platform links for non-members to prevent leaking invite URLs
+  // Strip sensitive data from the response
   const safeListingData = { ...listing };
+  // Always strip internal platform IDs — these are internal bot/channel identifiers
+  delete safeListingData.telegram_chat_id;
+  delete safeListingData.discord_channel_id;
   if (!isMember && !isAuthor) {
+    // Strip invite links for non-members
     delete safeListingData.telegram_link;
     delete safeListingData.discord_link;
   }
@@ -185,7 +189,7 @@ export async function PATCH(
         return NextResponse.json({ error: "Group size must be between 2 and 20" }, { status: 400 });
       }
 
-      // Cannot reduce below current member count
+      // Pre-check member count (authoritative check happens inside transaction below)
       const memberCount = (db
         .prepare("SELECT COUNT(*) as count FROM listing_members WHERE listing_id = ?")
         .get(listingId) as { count: number }).count;
@@ -226,19 +230,14 @@ export async function PATCH(
       updates.push("meeting_format = ?");
       values.push(meetingFormat);
     }
+    // Track whether maxGroupSize change needs is_full recalculation
+    let needsIsFullRecalc = false;
+    let parsedNewSize = 0;
     if (maxGroupSize !== undefined) {
-      const newSize = parseInt(String(maxGroupSize), 10);
+      parsedNewSize = parseInt(String(maxGroupSize), 10);
       updates.push("max_group_size = ?");
-      values.push(newSize);
-
-      // If increasing group size on a full listing, reopen it
-      const currentMemberCount = (db
-        .prepare("SELECT COUNT(*) as count FROM listing_members WHERE listing_id = ?")
-        .get(listingId) as { count: number }).count;
-      if (newSize > currentMemberCount && listing.is_full) {
-        updates.push("is_full = ?");
-        values.push(0);
-      }
+      values.push(parsedNewSize);
+      needsIsFullRecalc = true;
     }
     if (requiresApproval !== undefined) {
       updates.push("requires_approval = ?");
@@ -253,8 +252,34 @@ export async function PATCH(
       return NextResponse.json({ error: "No fields to update" }, { status: 400 });
     }
 
-    values.push(listingId);
-    db.prepare(`UPDATE listings SET ${updates.join(", ")} WHERE id = ?`).run(...values);
+    // Wrap in transaction to prevent race between is_full recalculation and concurrent joins
+    const updateTransaction = db.transaction(() => {
+      if (needsIsFullRecalc) {
+        // Re-read member count and is_full inside transaction to prevent stale data
+        const fresh = db.prepare("SELECT is_full FROM listings WHERE id = ?").get(listingId) as { is_full: number } | undefined;
+        const currentMemberCount = (db
+          .prepare("SELECT COUNT(*) as count FROM listing_members WHERE listing_id = ?")
+          .get(listingId) as { count: number }).count;
+
+        if (parsedNewSize < currentMemberCount) {
+          return { error: `Cannot reduce group size below current member count (${currentMemberCount})` };
+        }
+
+        if (parsedNewSize > currentMemberCount && fresh?.is_full) {
+          updates.push("is_full = ?");
+          values.push(0);
+        }
+      }
+
+      values.push(listingId);
+      db.prepare(`UPDATE listings SET ${updates.join(", ")} WHERE id = ?`).run(...values);
+      return null;
+    });
+
+    const txResult = updateTransaction();
+    if (txResult?.error) {
+      return NextResponse.json({ error: txResult.error }, { status: 400 });
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/app/lib/crypto-utils.ts
+++ b/app/lib/crypto-utils.ts
@@ -8,7 +8,9 @@ export function safeCompare(a: string, b: string): boolean {
   const bufA = Buffer.from(a);
   const bufB = Buffer.from(b);
   if (bufA.length !== bufB.length) {
-    // Still do a comparison to avoid leaking length info via timing
+    // Do a dummy comparison to add some constant work, though this does not
+    // fully mask length differences (bufA self-compare time varies with length).
+    // In practice, the secrets compared here are fixed-length env vars.
     timingSafeEqual(bufA, bufA);
     return false;
   }


### PR DESCRIPTION
## Summary
- **CRITICAL**: Wrapped PATCH `maxGroupSize` update in a `db.transaction()` to prevent race condition where a concurrent join could cause `is_full` to be incorrectly cleared, allowing members beyond the cap
- **IMPORTANT**: Strip `telegram_chat_id` and `discord_channel_id` from the GET `/api/listings/[id]` response — internal bot identifiers should not be exposed to clients
- **MINOR**: Fixed misleading comment in `safeCompare` about length-timing masking

## Test plan
- [x] All 198 tests pass
- [x] ESLint clean
- [x] Build succeeds
- [ ] Verify PATCH listing with maxGroupSize change works correctly
- [ ] Verify listing GET response no longer includes internal platform IDs

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)