### PR TITLE
fix: PATCH is_full gap, transaction safety, orphaned applications

### DIFF
--- a/app/__tests__/api/listings/listing-detail.test.ts
+++ b/app/__tests__/api/listings/listing-detail.test.ts
@@ -272,6 +272,23 @@ describe("GET /api/listings/[id]", () => {
     expect(data.listing.pendingApplicants.length).toBe(1);
   });
 
+  it("shows pending applicants to author even when requires_approval is off", async () => {
+    // This tests the fix for orphaned applications being invisible to authors
+    const listingId = insertListing(authorId, { requires_approval: 0 });
+    addMember(listingId, authorId);
+    mockSession.userId = authorId;
+
+    const applicant = insertUser("orphan@example.com", "Orphan");
+    // Simulate a pending application that was created before requires_approval was toggled off
+    testDb.prepare("INSERT INTO listing_applications (listing_id, user_id, status) VALUES (?, ?, 'pending')").run(listingId, applicant);
+
+    const req = createTestRequest(`/api/listings/${listingId}`);
+    const response = await GET(req, createParams(String(listingId)));
+    const { data } = await parseResponse<{ listing: { pendingApplicants: unknown[] } }>(response);
+
+    expect(data.listing.pendingApplicants.length).toBe(1);
+  });
+
   it("shows hasApplied status for applicants", async () => {
     const listingId = insertListing(authorId, { requires_approval: 1 });
     addMember(listingId, authorId);
@@ -413,6 +430,61 @@ describe("PATCH /api/listings/[id]", () => {
 
     expect(status).toBe(400);
     expect(data.error).toBe("No fields to update");
+  });
+
+  it("sets is_full=1 when maxGroupSize reduced to equal member count", async () => {
+    const listingId = insertListing(authorId, { max_group_size: 5 });
+    addMember(listingId, authorId);
+    const u2 = insertUser("u2b@test.com", "U2B");
+    addMember(listingId, u2);
+    const u3 = insertUser("u3b@test.com", "U3B");
+    addMember(listingId, u3);
+    // 3 members, reduce size to 3
+
+    const req = createTestRequest(`/api/listings/${listingId}`, {
+      method: "PATCH",
+      body: { maxGroupSize: 3 },
+    });
+    const response = await PATCH(req, createParams(String(listingId)));
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+
+    const updated = testDb.prepare("SELECT is_full, max_group_size FROM listings WHERE id = ?").get(listingId) as { is_full: number; max_group_size: number };
+    expect(updated.max_group_size).toBe(3);
+    expect(updated.is_full).toBe(1);
+  });
+
+  it("auto-rejects pending applications when requires_approval is toggled off", async () => {
+    const listingId = insertListing(authorId, { requires_approval: 1 });
+    addMember(listingId, authorId);
+
+    const applicant = insertUser("applicant@test.com", "Applicant");
+    testDb.prepare(
+      "INSERT INTO listing_applications (listing_id, user_id, status) VALUES (?, ?, 'pending')"
+    ).run(listingId, applicant);
+
+    const req = createTestRequest(`/api/listings/${listingId}`, {
+      method: "PATCH",
+      body: { requiresApproval: false },
+    });
+    const response = await PATCH(req, createParams(String(listingId)));
+    const { status, data } = await parseResponse(response);
+
+    expect(status).toBe(200);
+    expect(data.success).toBe(true);
+
+    // Check that the application was auto-rejected
+    const app = testDb.prepare(
+      "SELECT status, decided_at FROM listing_applications WHERE listing_id = ? AND user_id = ?"
+    ).get(listingId, applicant) as { status: string; decided_at: string };
+    expect(app.status).toBe("rejected");
+    expect(app.decided_at).toBeTruthy();
+
+    // Check that the listing no longer requires approval
+    const updated = testDb.prepare("SELECT requires_approval FROM listings WHERE id = ?").get(listingId) as { requires_approval: number };
+    expect(updated.requires_approval).toBe(0);
   });
 
   it("prevents reducing group size below current member count", async () => {

--- a/app/app/api/listings/[id]/route.ts
+++ b/app/app/api/listings/[id]/route.ts
@@ -73,8 +73,9 @@ export async function GET(
   }
 
   // Fetch pending applicants if the viewer is the author
+  // Show regardless of requires_approval — pending apps can exist after the flag is toggled off
   let pendingApplicants: { application_id: number; id: number; display_name: string; bio: string; applied_at: string }[] = [];
-  if (isAuthor && listing.requires_approval) {
+  if (isAuthor) {
     pendingApplicants = db
       .prepare(
         `SELECT la.id as application_id, u.id, u.display_name, u.bio, la.applied_at
@@ -252,8 +253,15 @@ export async function PATCH(
       return NextResponse.json({ error: "No fields to update" }, { status: 400 });
     }
 
+    // Check if requires_approval is being toggled off — need to handle orphaned pending apps
+    const togglingApprovalOff = requiresApproval === false && listing.requires_approval;
+
     // Wrap in transaction to prevent race between is_full recalculation and concurrent joins
+    // Use local copies of updates/values inside the transaction to avoid mutating outer arrays
     const updateTransaction = db.transaction(() => {
+      const txUpdates = [...updates];
+      const txValues = [...values];
+
       if (needsIsFullRecalc) {
         // Re-read member count and is_full inside transaction to prevent stale data
         const fresh = db.prepare("SELECT is_full FROM listings WHERE id = ?").get(listingId) as { is_full: number } | undefined;
@@ -265,14 +273,28 @@ export async function PATCH(
           return { error: `Cannot reduce group size below current member count (${currentMemberCount})` };
         }
 
-        if (parsedNewSize > currentMemberCount && fresh?.is_full) {
-          updates.push("is_full = ?");
-          values.push(0);
+        if (parsedNewSize === currentMemberCount && !fresh?.is_full) {
+          // Group is now exactly full — mark it
+          txUpdates.push("is_full = ?");
+          txValues.push(1);
+        } else if (parsedNewSize > currentMemberCount && fresh?.is_full) {
+          // Group has room now — reopen it
+          txUpdates.push("is_full = ?");
+          txValues.push(0);
         }
       }
 
-      values.push(listingId);
-      db.prepare(`UPDATE listings SET ${updates.join(", ")} WHERE id = ?`).run(...values);
+      txValues.push(listingId);
+      db.prepare(`UPDATE listings SET ${txUpdates.join(", ")} WHERE id = ?`).run(...txValues);
+
+      // When requires_approval is toggled off, auto-reject orphaned pending applications
+      // so those users can join directly instead of being stuck in limbo
+      if (togglingApprovalOff) {
+        db.prepare(
+          "UPDATE listing_applications SET status = 'rejected', decided_at = datetime('now') WHERE listing_id = ? AND status = 'pending'"
+        ).run(listingId);
+      }
+
       return null;
     });
 


### PR DESCRIPTION
## Summary
Fixes 3 bugs found in code review round 13 (#100):

- **CRITICAL: `is_full` never set to 1 when `maxGroupSize` reduced to exactly equal member count** — listing remained visible in browse and appeared joinable (though join transaction would reject). Added the missing `=== currentMemberCount` branch.
- **CRITICAL: Transaction mutates outer `updates`/`values` arrays** — structurally unsafe pattern that would corrupt SQL if the transaction function were called more than once. Fixed by using local copies (`txUpdates`/`txValues`) inside the transaction.
- **IMPORTANT: Users permanently locked out when `requires_approval` toggled off** — pending applicants became invisible to the author and blocked from direct join or re-application. Now auto-rejects pending applications when `requires_approval` is toggled from true to false, and shows pending applicants to the author regardless of the flag.

## Test plan
- [x] Added test: `is_full` set to 1 when `maxGroupSize` reduced to equal member count
- [x] Added test: pending applications auto-rejected when `requires_approval` toggled off
- [x] Added test: pending applicants visible to author even when `requires_approval` is off
- [x] All 201 tests pass (3 new)
- [x] ESLint clean
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)