### PR TITLE
fix: module-load freezing, stale sessions, TOCTOU races (#102)

### DIFF
--- a/app/__tests__/api/listings/listing-join.test.ts
+++ b/app/__tests__/api/listings/listing-join.test.ts
@@ -295,6 +295,6 @@ describe("POST /api/listings/[id]/join", () => {
     const req = createTestRequest(`/api/listings/${listingId}/join`, { method: "POST" });
     await POST(req, createParams(String(listingId)));
 
-    expect(notifyGroupFull).toHaveBeenCalledWith(listingId);
+    expect(notifyGroupFull).toHaveBeenCalledWith(listingId, expect.any(String), expect.any(String));
   });
 });

--- a/app/app/api/listings/[id]/applications/route.ts
+++ b/app/app/api/listings/[id]/applications/route.ts
@@ -119,7 +119,11 @@ export async function PATCH(
         notifyApplicationDecision(applicantUserId, listingId, "approved");
 
         if (result.isFull) {
-          notifyGroupFull(listingId);
+          notifyGroupFull(
+            listingId,
+            listing.book_title as string,
+            listing.platform_preference as string
+          );
           for (const app of result.rejectedApps) {
             notifyApplicationDecision(app.user_id, listingId, "rejected");
           }

--- a/app/app/api/listings/[id]/join/route.ts
+++ b/app/app/api/listings/[id]/join/route.ts
@@ -108,7 +108,11 @@ export async function POST(
   // When group just filled, skip new_member notification for the author
   // since they'll receive the more important group_full notification instead
   if (result.count === result.maxSize) {
-    notifyGroupFull(listingId);
+    notifyGroupFull(
+      listingId,
+      listing.book_title as string,
+      listing.platform_preference as string
+    );
   } else {
     notifyListingAuthor(listingId, session.displayName || "Someone");
   }

--- a/app/app/api/listings/[id]/route.ts
+++ b/app/app/api/listings/[id]/route.ts
@@ -259,6 +259,16 @@ export async function PATCH(
     // Wrap in transaction to prevent race between is_full recalculation and concurrent joins
     // Use local copies of updates/values inside the transaction to avoid mutating outer arrays
     const updateTransaction = db.transaction(() => {
+      // Re-check platform links inside the transaction to prevent TOCTOU race:
+      // a concurrent POST to /telegram or /discord could set a link between the
+      // outer guard (line 146) and this point
+      const current = db
+        .prepare("SELECT telegram_link, discord_link FROM listings WHERE id = ?")
+        .get(listingId) as { telegram_link: string | null; discord_link: string | null } | undefined;
+      if (current?.telegram_link || current?.discord_link) {
+        return { error: "Cannot edit a listing after the group chat link has been shared" };
+      }
+
       const txUpdates = [...updates];
       const txValues = [...values];
 

--- a/app/app/api/profile/route.ts
+++ b/app/app/api/profile/route.ts
@@ -10,6 +10,14 @@ export async function PATCH(req: NextRequest) {
 
   const { displayName, bio } = await req.json();
 
+  // Type-check before string operations to prevent TypeError on non-string input
+  if (typeof displayName !== "string") {
+    return NextResponse.json({ error: "Display name must be a string" }, { status: 400 });
+  }
+  if (bio !== undefined && typeof bio !== "string") {
+    return NextResponse.json({ error: "Bio must be a string" }, { status: 400 });
+  }
+
   if (!displayName || displayName.trim().length === 0) {
     return NextResponse.json({ error: "Display name is required" }, { status: 400 });
   }

--- a/app/lib/discord.ts
+++ b/app/lib/discord.ts
@@ -13,12 +13,23 @@
  * - Bot creates a text channel + invite link, saves to listing
  */
 
-const BOT_TOKEN = process.env.DISCORD_BOT_TOKEN || "";
-const CLIENT_ID = process.env.DISCORD_CLIENT_ID || "";
 const DISCORD_API = "https://discord.com/api/v10";
 
+/**
+ * Read bot credentials live from process.env on each call — not at module load time.
+ * Module-level constants would be frozen when the file is first imported,
+ * missing any env vars set or changed after server startup.
+ */
+function getBotToken(): string {
+  return process.env.DISCORD_BOT_TOKEN || "";
+}
+
+function getClientId(): string {
+  return process.env.DISCORD_CLIENT_ID || "";
+}
+
 export function isBotConfigured(): boolean {
-  return BOT_TOKEN.length > 0 && CLIENT_ID.length > 0;
+  return getBotToken().length > 0 && getClientId().length > 0;
 }
 
 /**
@@ -41,7 +52,7 @@ async function callApi<T = unknown>(
     const res = await fetch(`${DISCORD_API}${endpoint}`, {
       method,
       headers: {
-        Authorization: `Bot ${BOT_TOKEN}`,
+        Authorization: `Bot ${getBotToken()}`,
         "Content-Type": "application/json",
       },
       body: body ? JSON.stringify(body) : undefined,
@@ -87,7 +98,7 @@ export async function getBotInfo(): Promise<{
 export function generateBotInviteUrl(listingId: number): string {
   const permissions = 3089;
   const state = `listing_${listingId}`;
-  return `https://discord.com/oauth2/authorize?client_id=${CLIENT_ID}&permissions=${permissions}&scope=bot&state=${encodeURIComponent(state)}`;
+  return `https://discord.com/oauth2/authorize?client_id=${getClientId()}&permissions=${permissions}&scope=bot&state=${encodeURIComponent(state)}`;
 }
 
 /**

--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -1,14 +1,22 @@
 import nodemailer from "nodemailer";
 
-const isConfigured =
-  !!process.env.SMTP_HOST &&
-  !!process.env.SMTP_PORT &&
-  !!process.env.SMTP_FROM;
+/**
+ * Check SMTP config live from process.env on each call — not at module load time.
+ * Module-level constants would be frozen when the file is first imported,
+ * permanently returning false if SMTP vars aren't set at that exact moment.
+ */
+function checkConfigured(): boolean {
+  return (
+    !!process.env.SMTP_HOST &&
+    !!process.env.SMTP_PORT &&
+    !!process.env.SMTP_FROM
+  );
+}
 
 let transporter: nodemailer.Transporter | null = null;
 
 function getTransporter(): nodemailer.Transporter | null {
-  if (!isConfigured) return null;
+  if (!checkConfigured()) return null;
   if (!transporter) {
     transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
@@ -52,5 +60,5 @@ export async function sendEmail(
 }
 
 export function isEmailConfigured(): boolean {
-  return isConfigured;
+  return checkConfigured();
 }

--- a/app/lib/notifications.ts
+++ b/app/lib/notifications.ts
@@ -118,31 +118,36 @@ export function notifyApplicationDecision(
   }
 }
 
-export function notifyGroupFull(listingId: number) {
-  const listing = db
-    .prepare("SELECT book_title, platform_preference, author_id FROM listings WHERE id = ?")
-    .get(listingId) as { book_title: string; platform_preference: string; author_id: number } | undefined;
+/**
+ * Notify all members that the group is full.
+ * Accepts listing data as parameters to avoid re-querying outside the
+ * join transaction (which could return stale platform_preference if
+ * a concurrent PATCH changed it between the transaction commit and this call).
+ */
+export function notifyGroupFull(
+  listingId: number,
+  bookTitle: string,
+  platformPreference: string
+) {
   // Include all members (including the author) — author needs to know group is full to create the chat
   const members = db
     .prepare("SELECT user_id FROM listing_members WHERE listing_id = ?")
     .all(listingId) as { user_id: number }[];
 
-  if (listing) {
-    const platform = listing.platform_preference === "discord" ? "Discord" : "Telegram";
-    const botConfigured = listing.platform_preference === "discord"
-      ? !!process.env.DISCORD_BOT_TOKEN
-      : !!process.env.TELEGRAM_BOT_TOKEN;
-    const message = botConfigured
-      ? `The reading group for "${listing.book_title}" is now full! The ${platform} group will be set up automatically.`
-      : `The reading group for "${listing.book_title}" is now full! The organizer will share a ${platform} link soon.`;
+  const platform = platformPreference === "discord" ? "Discord" : "Telegram";
+  const botConfigured = platformPreference === "discord"
+    ? !!process.env.DISCORD_BOT_TOKEN
+    : !!process.env.TELEGRAM_BOT_TOKEN;
+  const message = botConfigured
+    ? `The reading group for "${bookTitle}" is now full! The ${platform} group will be set up automatically.`
+    : `The reading group for "${bookTitle}" is now full! The organizer will share a ${platform} link soon.`;
 
-    for (const member of members) {
-      createNotification(
-        member.user_id,
-        listingId,
-        "group_full",
-        message
-      );
-    }
+  for (const member of members) {
+    createNotification(
+      member.user_id,
+      listingId,
+      "group_full",
+      message
+    );
   }
 }

--- a/app/lib/session.ts
+++ b/app/lib/session.ts
@@ -1,5 +1,6 @@
 import { getIronSession, type SessionOptions } from "iron-session";
 import { cookies } from "next/headers";
+import db from "./db";
 
 export interface SessionData {
   userId?: number;
@@ -38,6 +39,20 @@ export async function requireAuth() {
   const session = await getSession();
   if (!session.userId) {
     return null;
+  }
+  // Verify the user still exists in the DB — a deleted user's cookie
+  // would otherwise grant full access until the session expires
+  const user = db
+    .prepare("SELECT id, display_name FROM users WHERE id = ?")
+    .get(session.userId) as { id: number; display_name: string } | undefined;
+  if (!user) {
+    session.destroy();
+    return null;
+  }
+  // Keep session displayName in sync with DB (handles stale cookies)
+  if (user.display_name !== session.displayName) {
+    session.displayName = user.display_name;
+    await session.save();
   }
   return session;
 }

--- a/app/lib/telegram.ts
+++ b/app/lib/telegram.ts
@@ -13,11 +13,21 @@
  * - Bot creates an invite link and saves it to the listing
  */
 
-const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || "";
-const TELEGRAM_API = `https://api.telegram.org/bot${BOT_TOKEN}`;
+/**
+ * Read bot token live from process.env on each call — not at module load time.
+ * Module-level constants would be frozen when the file is first imported,
+ * missing any env vars set or changed after server startup.
+ */
+function getBotToken(): string {
+  return process.env.TELEGRAM_BOT_TOKEN || "";
+}
+
+function getTelegramApi(): string {
+  return `https://api.telegram.org/bot${getBotToken()}`;
+}
 
 export function isBotConfigured(): boolean {
-  return BOT_TOKEN.length > 0;
+  return getBotToken().length > 0;
 }
 
 /**
@@ -27,7 +37,7 @@ async function callApi<T = unknown>(
   method: string,
   params?: Record<string, unknown>
 ): Promise<{ ok: boolean; result?: T; description?: string }> {
-  const res = await fetch(`${TELEGRAM_API}/${method}`, {
+  const res = await fetch(`${getTelegramApi()}/${method}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(params || {}),


### PR DESCRIPTION
## Summary
- **Read env vars live** from `process.env` in `telegram.ts`, `discord.ts`, and `email.ts` instead of freezing at module load time — `isBotConfigured()` and API calls now always use current values
- **`requireAuth` validates user existence** in DB and auto-syncs stale `displayName` from cookie — deleted users can no longer retain session access
- **`notifyGroupFull` accepts params** (`bookTitle`, `platformPreference`) instead of re-querying outside the join transaction — eliminates stale data risk from concurrent PATCH
- **PATCH listing re-checks platform links inside transaction** — prevents TOCTOU race where a concurrent `/telegram` or `/discord` POST sets a link between the outer guard and the update
- **Profile PATCH type-validates** `displayName`/`bio` before `.trim()` — prevents unhandled `TypeError` on non-string input

Closes #102

## Test plan
- [x] ESLint clean
- [x] All 201 tests pass (test updated for new `notifyGroupFull` signature)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)