### PR TITLE
fix: code review round 15 — LIKE injection, auth bypass, unbounded queries

### DIFF
--- a/app/app/api/listings/[id]/auto-discord/route.ts
+++ b/app/app/api/listings/[id]/auto-discord/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import db from "@/lib/db";
-import { getSession } from "@/lib/session";
+import { requireAuth } from "@/lib/session";
 import { isBotConfigured, generateBotInviteUrl } from "@/lib/discord";
 
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await getSession();
-  if (!session.userId) {
+  const session = await requireAuth();
+  if (!session) {
     return NextResponse.json(
       { error: "Authentication required" },
       { status: 401 }

--- a/app/app/api/listings/route.ts
+++ b/app/app/api/listings/route.ts
@@ -3,6 +3,11 @@ import db from "@/lib/db";
 
 const PAGE_SIZE = 20;
 
+/** Escape LIKE metacharacters so user input is matched literally */
+function escapeLike(value: string): string {
+  return value.replace(/[%_\\]/g, "\\$&");
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
 
@@ -34,8 +39,8 @@ export async function GET(request: NextRequest) {
   }
 
   if (q && q.length <= 300) {
-    conditions.push("(l.book_title LIKE ? OR l.book_author LIKE ?)");
-    params.push(`%${q}%`, `%${q}%`);
+    conditions.push("(l.book_title LIKE ? ESCAPE '\\' OR l.book_author LIKE ? ESCAPE '\\')");
+    params.push(`%${escapeLike(q)}%`, `%${escapeLike(q)}%`);
   }
 
   if (meetingFormat && ["voice", "text", "mixed"].includes(meetingFormat)) {
@@ -44,15 +49,18 @@ export async function GET(request: NextRequest) {
   }
 
   if (readingPace && readingPace.length <= 200) {
-    conditions.push("l.reading_pace LIKE ?");
-    params.push(`%${readingPace}%`);
+    conditions.push("l.reading_pace LIKE ? ESCAPE '\\'");
+    params.push(`%${escapeLike(readingPace)}%`);
   }
 
   const whereClause = conditions.join(" AND ");
 
-  let orderClause = "l.created_at DESC";
-  if (sort === "oldest") orderClause = "l.created_at ASC";
-  else if (sort === "start_date") orderClause = "l.start_date ASC";
+  const ORDER_MAP: Record<string, string> = {
+    newest: "l.created_at DESC",
+    oldest: "l.created_at ASC",
+    start_date: "l.start_date ASC",
+  };
+  const orderClause = ORDER_MAP[sort] ?? "l.created_at DESC";
 
   const offset = (page - 1) * PAGE_SIZE;
 

--- a/app/app/api/notifications/route.ts
+++ b/app/app/api/notifications/route.ts
@@ -48,9 +48,14 @@ export async function PATCH(req: NextRequest) {
       "UPDATE notifications SET is_read = 1 WHERE id = ? AND user_id = ?"
     ).run(notificationId, session.userId);
   } else {
-    // Mark all as read
+    // Mark all as read — use subquery with LIMIT to bound WAL lock duration
     db.prepare(
-      "UPDATE notifications SET is_read = 1 WHERE user_id = ?"
+      `UPDATE notifications SET is_read = 1
+       WHERE id IN (
+         SELECT id FROM notifications
+         WHERE user_id = ? AND is_read = 0
+         LIMIT 1000
+       )`
     ).run(session.userId);
   }
 

--- a/app/app/api/profile/reading/route.ts
+++ b/app/app/api/profile/reading/route.ts
@@ -47,6 +47,7 @@ export async function GET() {
     JOIN users u ON u.id = l.author_id
     WHERE lm.user_id = ?
     ORDER BY lm.joined_at DESC
+    LIMIT 200
   `).all(session.userId) as ReadingRow[];
 
   const today = new Date().toISOString().split("T")[0];

--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -14,10 +14,24 @@ function checkConfigured(): boolean {
 }
 
 let transporter: nodemailer.Transporter | null = null;
+let transporterConfigHash = "";
+
+/** Hash current SMTP env vars to detect config changes */
+function smtpConfigHash(): string {
+  return [
+    process.env.SMTP_HOST,
+    process.env.SMTP_PORT,
+    process.env.SMTP_SECURE,
+    process.env.SMTP_USER,
+    process.env.SMTP_PASS,
+    process.env.SMTP_FROM,
+  ].join("|");
+}
 
 function getTransporter(): nodemailer.Transporter | null {
   if (!checkConfigured()) return null;
-  if (!transporter) {
+  const currentHash = smtpConfigHash();
+  if (!transporter || currentHash !== transporterConfigHash) {
     transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
       port: parseInt(process.env.SMTP_PORT || "587", 10),
@@ -31,6 +45,7 @@ function getTransporter(): nodemailer.Transporter | null {
           }
         : {}),
     });
+    transporterConfigHash = currentHash;
   }
   return transporter;
 }


### PR DESCRIPTION
## Summary
- **auto-discord auth bypass**: replaced `getSession()` with `requireAuth()` to enforce DB user-existence check, matching all other authenticated endpoints
- **LIKE wildcard injection**: escaped `%`, `_`, `\` metacharacters in search inputs so literal searches work correctly and `%` can't match all rows
- **Unbounded mark-all-read**: bounded UPDATE to 1000 rows per call via subquery LIMIT to prevent WAL lock on large notification sets
- **Unbounded reading history**: added LIMIT 200 to prevent memory/bandwidth issues with power users
- **ORDER BY hardening**: replaced if/else chain with explicit allowlist map for sort parameter
- **Transporter cache invalidation**: nodemailer transporter now rebuilds when SMTP env vars change

## Test plan
- [x] All 201 tests pass
- [x] ESLint clean
- [x] TypeScript clean
- [x] Build clean

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)