### PR TITLE
fix: score type validation and DELETE TOCTOU race

### DIFF
--- a/app/app/api/listings/[id]/route.ts
+++ b/app/app/api/listings/[id]/route.ts
@@ -347,7 +347,7 @@ export async function DELETE(
     return NextResponse.json({ error: "Only the author can delete this listing" }, { status: 403 });
   }
 
-  // Cannot delete if a platform link has been shared
+  // Cannot delete if a platform link has been shared (initial check, re-verified inside transaction)
   if (listing.telegram_link || listing.discord_link) {
     return NextResponse.json(
       { error: "Cannot delete a listing after the group chat link has been shared" },
@@ -361,8 +361,16 @@ export async function DELETE(
       .prepare("SELECT user_id FROM listing_members WHERE listing_id = ? AND user_id != ?")
       .all(listingId, session.userId) as { user_id: number }[];
 
-    // Delete in a transaction (notifications sent after, so they aren't wiped)
+    // Delete in a transaction — re-check link guard inside to prevent TOCTOU race
     const deleteTransaction = db.transaction(() => {
+      const current = db
+        .prepare("SELECT telegram_link, discord_link FROM listings WHERE id = ?")
+        .get(listingId) as { telegram_link: string | null; discord_link: string | null } | undefined;
+
+      if (current?.telegram_link || current?.discord_link) {
+        throw new Error("LINK_SHARED");
+      }
+
       db.prepare("DELETE FROM pending_telegram_groups WHERE listing_id = ?").run(listingId);
       db.prepare("DELETE FROM listing_applications WHERE listing_id = ?").run(listingId);
       db.prepare("DELETE FROM listing_members WHERE listing_id = ?").run(listingId);
@@ -371,7 +379,17 @@ export async function DELETE(
       db.prepare("DELETE FROM listings WHERE id = ?").run(listingId);
     });
 
-    deleteTransaction();
+    try {
+      deleteTransaction();
+    } catch (txErr) {
+      if (txErr instanceof Error && txErr.message === "LINK_SHARED") {
+        return NextResponse.json(
+          { error: "Cannot delete a listing after the group chat link has been shared" },
+          { status: 400 }
+        );
+      }
+      throw txErr;
+    }
 
     // Send deletion notifications after transaction (listing_id is NULL since listing is gone)
     for (const member of members) {

--- a/app/app/api/ratings/route.ts
+++ b/app/app/api/ratings/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  if (score < 1 || score > 5 || !Number.isInteger(score)) {
+  if (typeof score !== "number" || !Number.isInteger(score) || score < 1 || score > 5) {
     return NextResponse.json(
       { error: "Score must be an integer between 1 and 5" },
       { status: 400 }


### PR DESCRIPTION
## Summary
- **Score type validation**: Added missing `typeof score !== "number"` guard in ratings route, matching the pattern used for `listingId` and `ratedUserId` — prevents string coercion from bypassing validation
- **DELETE TOCTOU race**: Re-read `telegram_link`/`discord_link` inside the DELETE transaction to prevent a race where a platform link is set between the initial guard check and the actual deletion — mirrors the existing approach in the PATCH handler

## Test plan
- [x] All 201 tests pass
- [x] Lint clean
- [x] Build clean
- [x] Verified `typeof` check rejects string scores that would otherwise pass comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)