### PR TITLE
fix: session destroy, PATCH body, abort leak, block probes (#108)

### DIFF
--- a/app/__tests__/api/notifications/notifications.test.ts
+++ b/app/__tests__/api/notifications/notifications.test.ts
@@ -170,6 +170,20 @@ describe("PATCH /api/notifications", () => {
     expect(unread.count).toBe(1);
   });
 
+  it("returns 400 for invalid/missing JSON body", async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 1 });
+
+    // Send a request with no body — req.json() should throw
+    const req = new (await import("next/server")).NextRequest(
+      new URL("/api/notifications", "http://localhost:3000"),
+      { method: "PATCH", headers: { "Content-Type": "application/json" } }
+    );
+    const response = await PATCH(req);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("Invalid request body");
+  });
+
   it("marks all notifications as read when no notificationId", async () => {
     mockRequireAuth.mockResolvedValue({ userId: 1 });
 

--- a/app/app/api/notifications/route.ts
+++ b/app/app/api/notifications/route.ts
@@ -37,7 +37,13 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
 
-  const { notificationId } = await req.json();
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  const { notificationId } = body;
 
   if (notificationId) {
     // Validate notificationId is a positive integer

--- a/app/components/BookSearch.tsx
+++ b/app/components/BookSearch.tsx
@@ -47,6 +47,7 @@ export default function BookSearch({ onSelect }: Props) {
   useEffect(() => {
     if (query.length < 3) {
       setResults([]);
+      if (abortRef.current) abortRef.current.abort();
       return;
     }
 

--- a/app/lib/session.ts
+++ b/app/lib/session.ts
@@ -46,7 +46,7 @@ export async function requireAuth() {
     .prepare("SELECT id, display_name FROM users WHERE id = ?")
     .get(session.userId) as { id: number; display_name: string } | undefined;
   if (!user) {
-    session.destroy();
+    await session.destroy();
     return null;
   }
   // Keep session displayName in sync with DB (handles stale cookies)

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Middleware to block invalid Server Action requests.
+ *
+ * This app uses zero Server Actions — all mutations go through API route handlers.
+ * Any request with a `Next-Action` header is from a bot/scanner probing for
+ * Next.js server actions. Returning 400 here prevents the framework from
+ * logging noisy "Failed to find Server Action" errors in PM2 logs.
+ */
+export function middleware(req: NextRequest) {
+  if (req.headers.get("next-action")) {
+    return NextResponse.json(
+      { error: "Server Actions are not supported" },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  // Run on all routes except static assets and internal Next.js paths
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## Summary
- **Await `session.destroy()`** — deleted user's cookie was never cleared because the async call wasn't awaited
- **PATCH /api/notifications body validation** — `req.json()` threw unhandled error on missing/malformed body (500 → now 400)
- **BookSearch abort leak** — in-flight fetch not aborted when query shortened below 3 chars
- **Middleware blocks `Next-Action` header probes** — bots sending `Next-Action: x` caused repeated PM2 error logs; app uses zero server actions so all such requests are illegitimate

## Test plan
- [x] All 202 tests pass (1 new test for PATCH body validation)
- [x] ESLint clean
- [x] Build succeeds with middleware compiled
- [ ] Verify PM2 error logs stop showing "Failed to find Server Action" after deploy

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)