### PR TITLE
fix: link exposure, reject race, type safety, validation (#110)

### DIFF
--- a/app/__tests__/api/auth/register.test.ts
+++ b/app/__tests__/api/auth/register.test.ts
@@ -130,6 +130,28 @@ describe("POST /api/auth/register", () => {
     expect(response.status).toBe(400);
   });
 
+  it("returns 400 when displayName is not a string", async () => {
+    const req = createTestRequest("/api/auth/register", {
+      method: "POST",
+      body: { email: "a@b.com", password: "password123", displayName: 12345 },
+    });
+
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("string");
+  });
+
+  it("returns 400 when email is not a string", async () => {
+    const req = createTestRequest("/api/auth/register", {
+      method: "POST",
+      body: { email: 123, password: "password123", displayName: "User" },
+    });
+
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+  });
+
   it("trims and lowercases email", async () => {
     const req = createTestRequest("/api/auth/register", {
       method: "POST",

--- a/app/__tests__/api/listings/listings.test.ts
+++ b/app/__tests__/api/listings/listings.test.ts
@@ -175,6 +175,23 @@ describe("GET /api/listings", () => {
     expect(data.listings.length).toBe(1);
   });
 
+  it("does not expose telegram_link or discord_link in listing list", async () => {
+    const listingId = insertListing(userId);
+    testDb.prepare("UPDATE listings SET telegram_link = ?, discord_link = ? WHERE id = ?").run(
+      "https://t.me/secret", "https://discord.gg/secret", listingId
+    );
+
+    const req = createTestRequest("/api/listings");
+    const response = await GET(req);
+    const { data } = await parseResponse<{ listings: Record<string, unknown>[] }>(response);
+
+    expect(data.listings.length).toBe(1);
+    expect(data.listings[0]).not.toHaveProperty("telegram_link");
+    expect(data.listings[0]).not.toHaveProperty("discord_link");
+    expect(data.listings[0]).not.toHaveProperty("telegram_chat_id");
+    expect(data.listings[0]).not.toHaveProperty("discord_channel_id");
+  });
+
   it("returns listings sorted newest first by default (by id descending)", async () => {
     const id1 = insertListing(userId, { book_title: "First" });
     const id2 = insertListing(userId, { book_title: "Second" });

--- a/app/__tests__/api/profile/reputation.test.ts
+++ b/app/__tests__/api/profile/reputation.test.ts
@@ -196,6 +196,20 @@ describe("GET /api/profile/reputation", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 for userId=0", async () => {
+    mockRequireAuth.mockResolvedValue(mockSession);
+    const req = createTestRequest("/api/profile/reputation?userId=0");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for negative userId", async () => {
+    mockRequireAuth.mockResolvedValue(mockSession);
+    const req = createTestRequest("/api/profile/reputation?userId=-5");
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
   it("counts groups rated by user", async () => {
     mockRequireAuth.mockResolvedValue(mockSession);
     // User1 rates User2

--- a/app/app/api/auth/register/route.ts
+++ b/app/app/api/auth/register/route.ts
@@ -15,6 +15,13 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    if (typeof email !== "string" || typeof password !== "string" || typeof displayName !== "string") {
+      return NextResponse.json(
+        { error: "Email, password, and display name must be strings" },
+        { status: 400 }
+      );
+    }
+
     // Rate limit: 3 registrations per IP per 15 minutes
     const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
     const { allowed, retryAfter } = checkRateLimit(`register:${ip}`, 3);

--- a/app/app/api/listings/[id]/applications/route.ts
+++ b/app/app/api/listings/[id]/applications/route.ts
@@ -138,12 +138,23 @@ export async function PATCH(
       return NextResponse.json({ error: message }, { status: 400 });
     }
   } else {
-    // Reject
-    db.prepare(
-      "UPDATE listing_applications SET status = 'rejected', decided_at = datetime('now') WHERE id = ?"
+    // Reject — use WHERE status='pending' to prevent overwriting a concurrent approval
+    const updated = db.prepare(
+      "UPDATE listing_applications SET status = 'rejected', decided_at = datetime('now') WHERE id = ? AND status = 'pending'"
     ).run(applicationId);
 
-    notifyApplicationDecision(applicantUserId, listingId, "rejected");
+    if (updated.changes === 0) {
+      return NextResponse.json(
+        { error: "Application already decided" },
+        { status: 409 }
+      );
+    }
+
+    try {
+      notifyApplicationDecision(applicantUserId, listingId, "rejected");
+    } catch (notifErr) {
+      console.error("Notification error (rejection succeeded):", notifErr);
+    }
 
     return NextResponse.json({ ok: true });
   }

--- a/app/app/api/listings/[id]/apply/route.ts
+++ b/app/app/api/listings/[id]/apply/route.ts
@@ -94,14 +94,23 @@ export async function POST(
     return { error: null, status: 200 };
   });
 
-  const result = applyTransaction();
+  try {
+    const result = applyTransaction();
 
-  if (result.error) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
+    if (result.error) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+
+    // Notify outside transaction (fire-and-forget)
+    try {
+      notifyApplicationReceived(listingId, session.displayName || "Someone");
+    } catch (notifErr) {
+      console.error("Notification error (application succeeded):", notifErr);
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Apply error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  // Notify outside transaction (fire-and-forget)
-  notifyApplicationReceived(listingId, session.displayName || "Someone");
-
-  return NextResponse.json({ ok: true });
 }

--- a/app/app/api/listings/[id]/discord/route.ts
+++ b/app/app/api/listings/[id]/discord/route.ts
@@ -43,10 +43,10 @@ export async function POST(
 
   if (
     !discordLink ||
-    discordLink.length > 512 ||
+    typeof discordLink !== "string" ||
     !(
-      discordLink.startsWith("https://discord.gg/") ||
-      discordLink.startsWith("https://discord.com/invite/")
+      /^https:\/\/discord\.gg\/[\w-]{1,480}$/.test(discordLink) ||
+      /^https:\/\/discord\.com\/invite\/[\w-]{1,470}$/.test(discordLink)
     )
   ) {
     return NextResponse.json(

--- a/app/app/api/listings/[id]/telegram/route.ts
+++ b/app/app/api/listings/[id]/telegram/route.ts
@@ -41,7 +41,7 @@ export async function POST(
 
   const { telegramLink } = await req.json();
 
-  if (!telegramLink || !telegramLink.startsWith("https://t.me/") || telegramLink.length > 512) {
+  if (!telegramLink || typeof telegramLink !== "string" || !/^https:\/\/t\.me\/[\w+/-]{1,490}$/.test(telegramLink)) {
     return NextResponse.json(
       { error: "Please provide a valid Telegram invite link (https://t.me/..., max 512 characters)" },
       { status: 400 }

--- a/app/app/api/listings/route.ts
+++ b/app/app/api/listings/route.ts
@@ -74,7 +74,10 @@ export async function GET(request: NextRequest) {
   const listings = db
     .prepare(
       `SELECT
-        l.*,
+        l.id, l.author_id, l.book_title, l.book_author, l.book_cover_url, l.book_olid,
+        l.language, l.reading_pace, l.start_date, l.meeting_format,
+        l.max_group_size, l.is_full, l.requires_approval, l.platform_preference,
+        l.created_at,
         u.display_name as author_name,
         (SELECT COUNT(*) FROM listing_members WHERE listing_id = l.id) as member_count
       FROM listings l

--- a/app/app/api/profile/reputation/route.ts
+++ b/app/app/api/profile/reputation/route.ts
@@ -21,7 +21,7 @@ export async function GET(req: NextRequest) {
   const userId = userIdParam ? parseInt(userIdParam, 10) : session.userId;
   const isOwnProfile = userId === session.userId;
 
-  if (userIdParam && isNaN(userId as number)) {
+  if (userIdParam && (isNaN(userId as number) || (userId as number) < 1)) {
     return NextResponse.json(
       { error: "Invalid userId parameter" },
       { status: 400 }

--- a/app/app/listings/[id]/ListingDetail.tsx
+++ b/app/app/listings/[id]/ListingDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import BookCover from "@/components/BookCover";
 
@@ -76,6 +76,7 @@ export default function ListingDetail() {
   const [ratingComments, setRatingComments] = useState<Record<number, string>>({});
   const [ratingSaving, setRatingSaving] = useState<number | null>(null);
   const [ratingMessage, setRatingMessage] = useState("");
+  const ratingsFetchedRef = useRef(false);
 
   const [notAvailable, setNotAvailable] = useState(false);
 
@@ -151,7 +152,8 @@ export default function ListingDetail() {
   }, [id]);
 
   useEffect(() => {
-    if (listing?.is_full && listing?.isMember) {
+    if (listing?.is_full && listing?.isMember && !ratingsFetchedRef.current) {
+      ratingsFetchedRef.current = true;
       fetchRatings();
     }
   }, [listing?.is_full, listing?.isMember, fetchRatings]);


### PR DESCRIPTION
## Summary
- **Listing browse endpoint** no longer exposes `telegram_link`, `discord_link`, `telegram_chat_id`, `discord_channel_id` — replaced `SELECT l.*` with explicit column list
- **Application reject** now uses `WHERE status='pending'` to prevent a concurrent approve from being silently overwritten by a reject
- **Register route** validates `email`, `password`, `displayName` are strings before calling `.length`/`.trim()` (was returning 500 on non-string input)
- **Apply route** wrapped in top-level try/catch for clean 500 responses on unexpected DB errors
- **Telegram/Discord link validation** uses strict regex requiring a path after the domain (rejects bare `https://t.me/`)
- **Reputation endpoint** rejects `userId=0` and negative values
- **fetchRatings** only fires once per page load via ref guard (prevents redundant API calls on every action)

## Test plan
- [x] 207 tests pass (5 new: register type check, listings link exposure, reputation userId bounds)
- [x] ESLint clean
- [x] Build clean
- [x] Verified `GET /api/listings` response no longer contains invite link fields

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)